### PR TITLE
Add fixed header and progress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ User progress is stored in `localStorage` under the key `progress-v1`. The app a
 
 The home page now shows three inline circles representing the number of completed sessions for the day. A button labeled with the exact week, day, and session starts the next session. Below the button is a short list of the upcoming module titles: Language, Math, and Knowledge.
 
+## Header
+
+A fixed header at the top of every page displays the current week, day, and session along with a home icon link back to the main menu.
+
 ## License
 
 Images used in the encyclopedia module are loaded from Unsplash using CC-licensed URLs.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,15 +2,19 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Home from './screens/Home'
 import Session from './screens/Session'
 import { ContentProvider } from './contexts/ContentProvider'
+import Header from './components/Header'
 import './App.css'
 
 const App = () => (
   <BrowserRouter>
     <ContentProvider>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/session" element={<Session />} />
-      </Routes>
+      <Header />
+      <div className="pt-16">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/session" element={<Session />} />
+        </Routes>
+      </div>
     </ContentProvider>
   </BrowserRouter>
 )

--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -45,11 +45,12 @@ const Carousel = ({ items, renderItem }) => {
           Next
         </button>
       </div>
-      <div className="flex justify-center gap-1">
+      <div className="flex justify-center gap-1" aria-label="carousel-progress">
         {items.map((_, i) => (
           <span
             key={i}
-            className={`w-2 h-2 rounded-full ${i === index ? 'bg-indigo-600' : 'bg-gray-300'}`}
+            data-testid="carousel-dot"
+            className={`progress-dot${i === index ? ' filled' : ''}`}
           />
         ))}
       </div>

--- a/src/components/Carousel.test.jsx
+++ b/src/components/Carousel.test.jsx
@@ -1,0 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import Carousel from './Carousel'
+
+describe('Carousel', () => {
+  it('updates progress dots when navigating', () => {
+    const items = ['a', 'b', 'c']
+    render(
+      <Carousel items={items} renderItem={(i) => <div>{i}</div>} />,
+    )
+
+    const next = screen.getByRole('button', { name: /next/i })
+    const dots = () => screen.getAllByTestId('carousel-dot')
+
+    expect(dots()[0]).toHaveClass('filled')
+    fireEvent.click(next)
+    expect(dots()[1]).toHaveClass('filled')
+  })
+})

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,16 @@
+import { Link } from 'react-router-dom'
+import { useContent } from '../contexts/ContentProvider'
+
+const Header = () => {
+  const { progress } = useContent()
+  return (
+    <header className="fixed top-0 left-0 w-full bg-white shadow p-4 flex items-center justify-between z-50" data-testid="app-header">
+      <Link to="/" aria-label="Home" className="text-2xl">🏠</Link>
+      <span className="text-sm font-semibold">
+        Week {progress.week} • Day {progress.day} • Session {progress.session}
+      </span>
+    </header>
+  )
+}
+
+export default Header

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -1,0 +1,26 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { MemoryRouter } from 'react-router-dom'
+import Header from './Header'
+import { useContent } from '../contexts/ContentProvider'
+
+vi.mock('../contexts/ContentProvider')
+
+describe('Header', () => {
+  it('shows progress and home link', () => {
+    useContent.mockReturnValue({ progress: { week: 1, day: 2, session: 3 } })
+
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Week 1 • Day 2 • Session 3')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
+  })
+})

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -7,7 +7,7 @@ const Home = () => {
   const titles = ['Language', 'Math', 'Knowledge']
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen space-y-4 p-4 text-center">
+    <div className="flex flex-col items-center justify-center min-h-screen space-y-4 p-4 pt-12 text-center">
       <h1 className="text-3xl font-bold">FlinkDink Flashcards</h1>
       <p>
         Week {progress.week} – Day {progress.day}

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -35,7 +35,7 @@ const Session = () => {
   const handlePrev = () => step > 0 && setStep(step - 1);
 
   return (
-    <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center">
+    <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-6">
       <h1 className="text-2xl font-bold">Week {progress.week} – Session</h1>
       <h2 className="text-lg text-gray-500">{titles[step]}</h2>
 


### PR DESCRIPTION
## Summary
- show a fixed header with current progress and home link
- adjust layout to account for the new header
- use `progress-dot` styling for carousel indicators
- document header component in README
- add unit tests for header and carousel progress

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685289562d48832ebfe2c46c2c56a372