### PR TITLE
Improve week fetch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ A fixed header at the top of every page displays the current week, day, and sess
 
 Carousel navigation buttons now include descriptive ARIA labels and retain their focus outlines for improved keyboard navigation.
 
+## Loading States
+
+The session screen shows a skeleton placeholder while week data loads. If loading fails, an error message is displayed.
+
 ## License
 
 Images used in the encyclopedia module are loaded from Unsplash using CC-licensed URLs.

--- a/src/components/LoadingSkeleton.jsx
+++ b/src/components/LoadingSkeleton.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const LoadingSkeleton = () => (
+  <div className="flex items-center justify-center h-screen" data-testid="loading">
+    <div className="animate-pulse space-y-4 w-60">
+      <div className="h-6 bg-gray-200 rounded" />
+      <div className="h-4 bg-gray-200 rounded w-1/2" />
+      <div className="h-32 bg-gray-200 rounded" />
+    </div>
+  </div>
+)
+
+export default LoadingSkeleton

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -24,18 +24,22 @@ export const ContentProvider = ({ children }) => {
   const [progress, setProgress] = useState(loadProgress())
   const [weekData, setWeekData] = useState(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
 
   useEffect(() => {
     const loadWeek = async () => {
       setLoading(true)
+      setError(null)
       const id = String(progress.week).padStart(3, '0')
       try {
         const res = await fetch(`/weeks/week${id}.json`)
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
         const data = await res.json()
         setWeekData(data)
       } catch (err) {
         console.error('Failed to load week data', err)
         setWeekData(null)
+        setError(err)
       } finally {
         setLoading(false)
       }
@@ -65,7 +69,7 @@ export const ContentProvider = ({ children }) => {
   }
 
   return (
-    <ContentContext.Provider value={{ progress, weekData, loading, completeSession }}>
+    <ContentContext.Provider value={{ progress, weekData, loading, error, completeSession }}>
       {children}
     </ContentContext.Provider>
   )

--- a/src/contexts/ContentProvider.test.jsx
+++ b/src/contexts/ContentProvider.test.jsx
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ContentProvider, useContent } from './ContentProvider'
+
+const TestConsumer = () => {
+  const { weekData, loading, error } = useContent()
+  if (loading) return <div>loading</div>
+  if (error) return <div data-testid="error">{error.message}</div>
+  return <div data-testid="language">{weekData.language[0]}</div>
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ContentProvider fetch handling', () => {
+  it('loads week data successfully', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ language: ['hi'], mathWindowStart: 0, encyclopedia: [] }),
+    })
+
+    render(
+      <ContentProvider>
+        <TestConsumer />
+      </ContentProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('language')).toBeInTheDocument())
+    expect(screen.getByTestId('language')).toHaveTextContent('hi')
+  })
+
+  it('handles fetch failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 404 })
+
+    render(
+      <ContentProvider>
+        <TestConsumer />
+      </ContentProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeInTheDocument())
+    expect(screen.getByTestId('error')).toHaveTextContent('404')
+  })
+})

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -1,23 +1,32 @@
-import { useState, useEffect } from 'react';
-import { useContent } from '../contexts/ContentProvider';
+import { useState, useEffect } from 'react'
+import { useContent } from '../contexts/ContentProvider'
+import LoadingSkeleton from '../components/LoadingSkeleton'
 import LanguageModule from '../modules/LanguageModule';
 import MathModule from '../modules/MathModule';
 import EncyclopediaModule from '../modules/EncyclopediaModule';
 
 const Session = () => {
-  const { progress, weekData, loading, completeSession } = useContent();
+  const { progress, weekData, loading, error, completeSession } = useContent()
   const [step, setStep] = useState(0);
 
   useEffect(() => {
     if (!loading) window.scrollTo(0, 0);
   }, [step, loading]);
 
-  if (loading || !weekData) {
+  if (loading) {
+    return <LoadingSkeleton />
+  }
+
+  if (error) {
     return (
-      <div className="flex items-center justify-center h-screen">
-        Loading...
+      <div className="flex items-center justify-center h-screen text-red-600">
+        Failed to load week data: {error.message}
       </div>
-    );
+    )
+  }
+
+  if (!weekData) {
+    return null
   }
 
   const titles = ['📝 Language', '🔢 Math Dots', '🦁 Encyclopedia'];

--- a/src/screens/Session.test.jsx
+++ b/src/screens/Session.test.jsx
@@ -1,0 +1,24 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import Session from './Session'
+import { useContent } from '../contexts/ContentProvider'
+
+vi.mock('../contexts/ContentProvider')
+
+describe('Session screen', () => {
+  it('shows skeleton when loading', () => {
+    useContent.mockReturnValue({ loading: true })
+    render(<Session />)
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+  })
+
+  it('shows error when week data fails', () => {
+    useContent.mockReturnValue({ loading: false, error: new Error('404') })
+    render(<Session />)
+    expect(screen.getByText(/failed to load week data/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add a loading skeleton component
- surface fetch errors and log them
- show skeleton and error in session screen
- document the new loading states
- test week data fetch success and failure

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68528b206ffc832eaf155d47dd88bc51