### PR TITLE
Fix Tailwind build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ npm run dev
 Tailwind CSS 4.x requires any files using `@apply` to be included in the
 `content` array of `tailwind.config.js`. The configuration already references
 `src/index.css`, so unknown utility class errors should not occur during
-development.
+development. If you see a build error about unknown utility classes, make sure
+the `@tailwindcss/postcss` package is installed and listed in
+`postcss.config.js`.
 
 Lint the code with ESLint:
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,8 @@
 /* App level styles */
-body {
-  @apply bg-gray-100;
+@tailwind utilities;
+@reference utilities from tailwindcss;
+@layer base {
+  body {
+    @apply bg-gray-100;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@reference utilities from tailwindcss;
 
 @layer components {
   .btn {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx,css}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add `@reference` directive for Tailwind utilities
- ensure global styles processed by Tailwind
- convert `tailwind.config.js` to CommonJS
- document PostCSS plugin requirement

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Cannot apply unknown utility class `px-5`)*

------
https://chatgpt.com/codex/tasks/task_e_68529117463c832ea7eca6d22e7af39d