### PR TITLE
Add load error banner with retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ All screens now display a reusable skeleton placeholder while week data loads.
 The skeleton uses an animated shimmer and sets `aria-busy="true"` for assistive
 technology. If loading fails, an error message is displayed.
 
+## Error Handling
+
+When week data fails to load, a red banner appears below the header with the
+HTTP status or message. The banner includes a **Retry** button that re-runs the
+`loadWeek` request.
+
 ## License
 
 Images used in the encyclopedia module are loaded from Unsplash using CC-licensed URLs.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Home from './screens/Home'
 import Session from './screens/Session'
 import { ContentProvider } from './contexts/ContentProvider'
 import Header from './components/Header'
+import ErrorBanner from './components/ErrorBanner'
 import './App.css'
 
 const App = () => (
@@ -10,6 +11,7 @@ const App = () => (
     <ContentProvider>
       <Header />
       <div className="pt-16">
+        <ErrorBanner />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/session" element={<Session />} />

--- a/src/components/ErrorBanner.jsx
+++ b/src/components/ErrorBanner.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useContent } from '../contexts/ContentProvider'
+
+const ErrorBanner = () => {
+  const { error, loadWeek } = useContent()
+  if (!error) return null
+  return (
+    <div className="bg-red-100 text-red-700 p-2 text-center" role="alert">
+      Failed to load week data: {error.message}
+      <button type="button" onClick={loadWeek} className="ml-2 underline">
+        Retry
+      </button>
+    </div>
+  )
+}
+
+export default ErrorBanner

--- a/src/components/ErrorBanner.test.jsx
+++ b/src/components/ErrorBanner.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import ErrorBanner from './ErrorBanner'
+import { useContent } from '../contexts/ContentProvider'
+
+jest.mock('../contexts/ContentProvider')
+
+describe('ErrorBanner', () => {
+  it('renders nothing when no error', () => {
+    useContent.mockReturnValue({ error: null })
+    const { container } = render(<ErrorBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows error message and calls loadWeek on retry', () => {
+    const loadWeek = jest.fn()
+    useContent.mockReturnValue({ error: new Error('404'), loadWeek })
+    render(<ErrorBanner />)
+    expect(screen.getByRole('alert')).toHaveTextContent('404')
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(loadWeek).toHaveBeenCalled()
+  })
+})

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react'
 
 const PROGRESS_VERSION = 1
 const PROGRESS_KEY = 'progress-v1'
@@ -35,25 +41,27 @@ export const ContentProvider = ({ children }) => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
-  useEffect(() => {
-    const loadWeek = async () => {
-      setLoading(true)
-      setError(null)
-      const id = String(progress.week).padStart(3, '0')
-      try {
-        const res = await fetch(`/weeks/week${id}.json`)
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
-        const data = await res.json()
-        setWeekData(data)
-      } catch (err) {
-        console.error('Failed to load week data', err)
-        setWeekData(null)
-        setError(err)
-      } finally {
-        setLoading(false)
-      }
+  const loadWeek = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    const id = String(progress.week).padStart(3, '0')
+    try {
+      const res = await fetch(`/weeks/week${id}.json`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setWeekData(data)
+    } catch (err) {
+      console.error('Failed to load week data', err)
+      setWeekData(null)
+      setError(err)
+    } finally {
+      setLoading(false)
     }
+  }, [progress.week])
+
+  useEffect(() => {
     loadWeek()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [progress.week])
 
   const saveProgress = (p) => {
@@ -79,7 +87,9 @@ export const ContentProvider = ({ children }) => {
   }
 
   return (
-    <ContentContext.Provider value={{ progress, weekData, loading, error, completeSession }}>
+    <ContentContext.Provider
+      value={{ progress, weekData, loading, error, completeSession, loadWeek }}
+    >
       {children}
     </ContentContext.Provider>
   )

--- a/src/screens/WeekErrorFlow.test.jsx
+++ b/src/screens/WeekErrorFlow.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Home from './Home'
+import ErrorBanner from '../components/ErrorBanner'
+import { ContentProvider } from '../contexts/ContentProvider'
+
+describe('week load error flow', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete global.fetch
+  })
+
+  it('surfaces banner and retries', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ language: ['hi'], mathWindowStart: 0, encyclopedia: [] }),
+      })
+    global.fetch = fetchMock
+
+    render(
+      <MemoryRouter>
+        <ContentProvider>
+          <ErrorBanner />
+          <Home />
+        </ContentProvider>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+})


### PR DESCRIPTION
## Summary
- handle fetch failure in `ContentProvider` with retryable function
- display new `ErrorBanner` below the header
- document error handling behaviour
- test banner component and integration flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685297e40fec832e829474b8729cd670