### PR TITLE
Fix math dot visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ User progress is stored in `localStorage` under the key `progress-v1`. Each save
 
 The home page now shows three inline circles representing the number of completed sessions for the day. A button labeled with the exact week, day, and session starts the next session. Below the button is a short list of the upcoming module titles: Language, Math, and Knowledge.
 
+The math module's red dots are now styled entirely inline. Each dot uses `inline-block` positioning with explicit width, height, background color, and border radius so they remain visible even if Tailwind utilities are unavailable.
+
 ## Header
 
 A fixed header at the top of every page displays the current week, day, and session along with a home icon link back to the main menu.

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -18,8 +18,15 @@ const MathModule = ({ start }) => {
             {positions.map((pos, i) => (
               <span
                 key={i}
-                className="absolute w-4 h-4 bg-red-500 rounded-full"
-                style={{ top: pos.top, left: pos.left }}
+                className="absolute inline-block"
+                style={{
+                  top: pos.top,
+                  left: pos.left,
+                  width: '1rem',
+                  height: '1rem',
+                  borderRadius: '9999px',
+                  backgroundColor: '#ef4444',
+                }}
               />
             ))}
           </div>

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -7,4 +7,14 @@ describe('MathModule', () => {
     const dots = screen.getAllByTestId('carousel-dot');
     expect(dots).toHaveLength(10);
   });
+
+  it('renders visible dots for each math slide', () => {
+    const { container } = render(<MathModule start={1} />);
+    const dot = container.querySelector('span');
+    expect(dot).not.toBeNull();
+    const computed = getComputedStyle(dot);
+    expect(parseFloat(computed.width)).toBeGreaterThan(0);
+    expect(parseFloat(computed.height)).toBeGreaterThan(0);
+    expect(computed.backgroundColor).not.toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- style math dots entirely via inline styles
- adjust MathModule test for inline styles
- document the inline styles in README

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68529a93e270832e90ee709db7026f89