### PR TITLE
Use local encyclopedia images

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ HTTP status or message. The banner includes a **Retry** button that re-runs the
 
 ## License
 
-Images used in the encyclopedia module are loaded from Unsplash using CC-licensed URLs.
+Images used in the encyclopedia module are stored locally under `public/images`.
+Each file is a small SVG placeholder so the app works without internet access.

--- a/public/images/bear.svg
+++ b/public/images/bear.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bear</text>
+</svg>

--- a/public/images/elephant.svg
+++ b/public/images/elephant.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Elephant</text>
+</svg>

--- a/public/images/giraffe.svg
+++ b/public/images/giraffe.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Giraffe</text>
+</svg>

--- a/public/images/kangaroo.svg
+++ b/public/images/kangaroo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Kangaroo</text>
+</svg>

--- a/public/images/koala.svg
+++ b/public/images/koala.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Koala</text>
+</svg>

--- a/public/images/lion.svg
+++ b/public/images/lion.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Lion</text>
+</svg>

--- a/public/images/monkey.svg
+++ b/public/images/monkey.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Monkey</text>
+</svg>

--- a/public/images/panda.svg
+++ b/public/images/panda.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Panda</text>
+</svg>

--- a/public/images/tiger.svg
+++ b/public/images/tiger.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Tiger</text>
+</svg>

--- a/public/images/zebra.svg
+++ b/public/images/zebra.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Zebra</text>
+</svg>

--- a/public/weeks/week001.json
+++ b/public/weeks/week001.json
@@ -13,15 +13,15 @@
   ],
   "mathWindowStart": 1,
   "encyclopedia": [
-    { "id": "lion", "title": "Lion", "fact": "Lions live in prides.", "image": "https://source.unsplash.com/featured/?lion" },
-    { "id": "tiger", "title": "Tiger", "fact": "Tigers have striped fur.", "image": "https://source.unsplash.com/featured/?tiger" },
-    { "id": "bear", "title": "Bear", "fact": "Bears hibernate in winter.", "image": "https://source.unsplash.com/featured/?bear" },
-    { "id": "giraffe", "title": "Giraffe", "fact": "Giraffes have long necks.", "image": "https://source.unsplash.com/featured/?giraffe" },
-    { "id": "zebra", "title": "Zebra", "fact": "Zebras have black and white stripes.", "image": "https://source.unsplash.com/featured/?zebra" },
-    { "id": "monkey", "title": "Monkey", "fact": "Monkeys are very playful.", "image": "https://source.unsplash.com/featured/?monkey" },
-    { "id": "elephant", "title": "Elephant", "fact": "Elephants never forget.", "image": "https://source.unsplash.com/featured/?elephant" },
-    { "id": "panda", "title": "Panda", "fact": "Pandas love bamboo.", "image": "https://source.unsplash.com/featured/?panda" },
-    { "id": "koala", "title": "Koala", "fact": "Koalas sleep a lot.", "image": "https://source.unsplash.com/featured/?koala" },
-    { "id": "kangaroo", "title": "Kangaroo", "fact": "Kangaroos carry babies in pouches.", "image": "https://source.unsplash.com/featured/?kangaroo" }
+    { "id": "lion", "title": "Lion", "fact": "Lions live in prides.", "image": "/images/lion.svg" },
+    { "id": "tiger", "title": "Tiger", "fact": "Tigers have striped fur.", "image": "/images/tiger.svg" },
+    { "id": "bear", "title": "Bear", "fact": "Bears hibernate in winter.", "image": "/images/bear.svg" },
+    { "id": "giraffe", "title": "Giraffe", "fact": "Giraffes have long necks.", "image": "/images/giraffe.svg" },
+    { "id": "zebra", "title": "Zebra", "fact": "Zebras have black and white stripes.", "image": "/images/zebra.svg" },
+    { "id": "monkey", "title": "Monkey", "fact": "Monkeys are very playful.", "image": "/images/monkey.svg" },
+    { "id": "elephant", "title": "Elephant", "fact": "Elephants never forget.", "image": "/images/elephant.svg" },
+    { "id": "panda", "title": "Panda", "fact": "Pandas love bamboo.", "image": "/images/panda.svg" },
+    { "id": "koala", "title": "Koala", "fact": "Koalas sleep a lot.", "image": "/images/koala.svg" },
+    { "id": "kangaroo", "title": "Kangaroo", "fact": "Kangaroos carry babies in pouches.", "image": "/images/kangaroo.svg" }
   ]
 }


### PR DESCRIPTION
## Summary
- host encyclopedia images locally under `public/images`
- reference local SVG placeholders in week data
- document that images are local

## Testing
- `npm install`
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852a0598078832ea663b9ad56b25861