### PR TITLE
Add previous week navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ User progress is stored in `localStorage` under the key `progress-v1`. Each save
 
 The home page now shows three inline circles representing the number of completed sessions for the day. A button labeled with the exact week, day, and session starts the next session. Below the button is a short list of the upcoming module titles: Language, Math, and Knowledge.
 
+When you're beyond week 1, a **Previous Week** button lets you revisit the prior week's content.
+
 guteek-codex/update-mathmodule-and-extend-tests
 The math module's red dots are now styled entirely inline. Each dot uses `inline-block` positioning with explicit width, height, background color, and border radius so they remain visible even if Tailwind utilities are unavailable.
 

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -86,9 +86,23 @@ export const ContentProvider = ({ children }) => {
     saveProgress({ week, day, session })
   }
 
+  const previousWeek = () => {
+    if (progress.week > 1) {
+      saveProgress({ week: progress.week - 1, day: 1, session: 1 })
+    }
+  }
+
   return (
     <ContentContext.Provider
-      value={{ progress, weekData, loading, error, completeSession, loadWeek }}
+      value={{
+        progress,
+        weekData,
+        loading,
+        error,
+        completeSession,
+        loadWeek,
+        previousWeek,
+      }}
     >
       {children}
     </ContentContext.Provider>

--- a/src/contexts/ContentProvider.test.jsx
+++ b/src/contexts/ContentProvider.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, cleanup } from '@testing-library/react'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
 import { ContentProvider, useContent } from './ContentProvider'
 
 const TestConsumer = () => {
@@ -81,5 +81,44 @@ describe('progress version handling', () => {
     )
 
     expect(screen.getByTestId('progress')).toHaveTextContent('1')
+  })
+})
+
+describe('previousWeek', () => {
+  const PrevConsumer = () => {
+    const { progress, previousWeek } = useContent()
+    return (
+      <div>
+        <span data-testid="week">{progress.week}</span>
+        <span data-testid="day">{progress.day}</span>
+        <span data-testid="session">{progress.session}</span>
+        <button type="button" onClick={previousWeek}>
+          prev
+        </button>
+      </div>
+    )
+  }
+
+  it('moves back one week and resets day and session', () => {
+    localStorage.setItem(
+      'progress-v1',
+      JSON.stringify({ version: 1, week: 3, day: 4, session: 2 }),
+    )
+
+    render(
+      <ContentProvider>
+        <PrevConsumer />
+      </ContentProvider>,
+    )
+
+    expect(screen.getByTestId('week')).toHaveTextContent('3')
+    fireEvent.click(screen.getByText('prev'))
+    expect(screen.getByTestId('week')).toHaveTextContent('2')
+    expect(screen.getByTestId('day')).toHaveTextContent('1')
+    expect(screen.getByTestId('session')).toHaveTextContent('1')
+    const stored = JSON.parse(localStorage.getItem('progress-v1'))
+    expect(stored.week).toBe(2)
+    expect(stored.day).toBe(1)
+    expect(stored.session).toBe(1)
   })
 })

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -3,7 +3,7 @@ import { useContent } from '../contexts/ContentProvider'
 import LoadingSkeleton from '../components/LoadingSkeleton'
 
 const Home = () => {
-  const { progress, loading } = useContent()
+  const { progress, loading, previousWeek } = useContent()
   if (loading) return <LoadingSkeleton />
   const completed = progress.session - 1
   const titles = ['Language', 'Math', 'Knowledge']
@@ -31,6 +31,11 @@ const Home = () => {
       <Link to="/session" className="btn">
         Start Week {progress.week} • Day {progress.day} • Session {progress.session}
       </Link>
+      {progress.week > 1 && (
+        <button type="button" onClick={previousWeek} className="btn">
+          ← Previous Week
+        </button>
+      )}
     </div>
   )
 }

--- a/src/screens/Home.test.jsx
+++ b/src/screens/Home.test.jsx
@@ -7,7 +7,11 @@ jest.mock('../contexts/ContentProvider')
 
 describe('Home screen', () => {
   it('renders progress and next session titles', () => {
-    useContent.mockReturnValue({ progress: { version: 1, week: 2, day: 3, session: 2 }, loading: false })
+    useContent.mockReturnValue({
+      progress: { version: 1, week: 2, day: 3, session: 2 },
+      loading: false,
+      previousWeek: jest.fn(),
+    })
 
     render(
       <MemoryRouter>
@@ -30,6 +34,7 @@ describe('Home screen', () => {
     expect(screen.getByText('Language')).toBeInTheDocument()
     expect(screen.getByText('Math')).toBeInTheDocument()
     expect(screen.getByText('Knowledge')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /previous week/i })).toBeInTheDocument()
   })
 
   it('shows skeleton when loading', () => {
@@ -40,5 +45,20 @@ describe('Home screen', () => {
       </MemoryRouter>,
     )
     expect(screen.getByTestId('loading')).toBeInTheDocument()
+  })
+
+  it('hides previous week button on week one', () => {
+    useContent.mockReturnValue({
+      progress: { version: 1, week: 1, day: 1, session: 1 },
+      loading: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByRole('button', { name: /previous week/i })).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- let users return to a previous week
- expose `previousWeek` in `ContentProvider`
- show a button on the home screen when past week one
- document the new option in the README
- test new behaviour and update existing tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852ab397ec4832e896ede6ee2b3078c