### PR TITLE
Fix build error for tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ npm install
 npm run dev
 ```
 
-Tailwind CSS is processed with `@tailwindcss/postcss`. If you encounter a build
-error about unknown utility classes (for example `bg-orange-500`), verify the
-plugin is installed and listed in `postcss.config.js`. Custom styles that use
-`@apply` should be wrapped in a `@layer` block so Tailwind can register the
-utilities correctly.
+Tailwind CSS is processed with `@tailwindcss/postcss`. If you see a build error
+about unknown utilities (for example `bg-orange-500`), make sure the plugin is
+installed and listed in `postcss.config.js`. When a particular utility still
+fails to apply, replace it with an equivalent CSS declaration inside a `@layer`
+block.
 
 Lint the code with ESLint:
 

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,12 @@
   }
 
   .badge {
-    @apply bg-orange-500 text-white px-2 py-1 rounded-full text-sm font-semibold;
+    /* Use explicit color to avoid unknown Tailwind utility errors */
+    background-color: #f97316; /* tailwind orange-500 */
+    color: white;
+    padding: 0.25rem 0.5rem;
+    border-radius: 9999px;
+    font-size: 0.875rem; /* text-sm */
+    font-weight: 600; /* font-semibold */
   }
 }


### PR DESCRIPTION
## Summary
- avoid failing `@apply` by inlining CSS for the badge
- update README notes about handling unknown utilities

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852b6f4eac4832e976125856c8dd45b