### PR TITLE
Add modular home page components

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The math module's red dots are now styled entirely inline. Each dot uses `inline
 Math slides now follow a sliding window of ten numbers. From week two onward the first five numbers are shown in a random order while the upper five stay sequential.
 
 
-## Header
+## Navigation
 
-A fixed header at the top of every page displays the current week, day, and session along with a home icon link back to the main menu.
+The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
 
 ## Accessibility
 

--- a/src/components/CTAButton.jsx
+++ b/src/components/CTAButton.jsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom'
+
+const CTAButton = ({ children, to, ...props }) => {
+  if (to) {
+    return (
+      <Link to={to} className="cta-btn" {...props}>
+        {children}
+      </Link>
+    )
+  }
+  return (
+    <button type="button" className="cta-btn" {...props}>
+      {children}
+    </button>
+  )
+}
+
+export default CTAButton

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,8 @@
+const Hero = ({ headline, tagline }) => (
+  <div className="text-center space-y-2">
+    <h1 className="text-3xl font-bold">{headline}</h1>
+    <p className="text-lg text-gray-600">{tagline}</p>
+  </div>
+)
+
+export default Hero

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom'
+import SettingsButton from './SettingsButton'
+
+const NavBar = () => (
+  <nav className="flex items-center justify-between p-4 shadow">
+    <Link to="/" aria-label="Home" className="icon-btn">
+      🏠
+    </Link>
+    <span className="font-bold text-xl">FlinkDink</span>
+    <SettingsButton />
+  </nav>
+)
+
+export default NavBar

--- a/src/components/NavBar.test.jsx
+++ b/src/components/NavBar.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import NavBar from './NavBar'
+
+describe('NavBar', () => {
+  it('renders home link and settings button', () => {
+    render(
+      <MemoryRouter>
+        <NavBar />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
+    expect(screen.getByText('FlinkDink')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument()
+  })
+})

--- a/src/components/ProgressStrip.jsx
+++ b/src/components/ProgressStrip.jsx
@@ -1,0 +1,21 @@
+const ProgressStrip = ({ week, day, session, completedSessions }) => (
+  <div className="text-center space-y-2">
+    <p className="font-semibold">
+      Week {week} • Day {day} • Session {session}
+    </p>
+    <div className="flex justify-center gap-1" aria-label="sessions-progress">
+      {[1, 2, 3].map((n) => (
+        <span
+          key={n}
+          data-testid="session-dot"
+          className={`progress-dot${n <= completedSessions ? ' filled' : ''}`}
+        />
+      ))}
+    </div>
+    <p className="text-sm text-gray-600">
+      {completedSessions} of 3 sessions complete
+    </p>
+  </div>
+)
+
+export default ProgressStrip

--- a/src/components/SettingsButton.jsx
+++ b/src/components/SettingsButton.jsx
@@ -1,0 +1,12 @@
+const SettingsButton = ({ onClick }) => (
+  <button
+    type="button"
+    aria-label="Settings"
+    className="icon-btn"
+    onClick={onClick}
+  >
+    ⚙
+  </button>
+)
+
+export default SettingsButton

--- a/src/components/ThemeList.jsx
+++ b/src/components/ThemeList.jsx
@@ -1,0 +1,9 @@
+const ThemeList = ({ languageTheme, mathRange, knowledgeTheme }) => (
+  <ul className="text-sm text-gray-600 space-y-1 list-disc list-inside text-left">
+    {languageTheme && <li>{languageTheme}</li>}
+    {mathRange && <li>{mathRange}</li>}
+    {knowledgeTheme && <li>{knowledgeTheme}</li>}
+  </ul>
+)
+
+export default ThemeList

--- a/src/index.css
+++ b/src/index.css
@@ -46,4 +46,12 @@
     font-size: 0.875rem; /* text-sm */
     font-weight: 600; /* font-semibold */
   }
+
+  .icon-btn {
+    @apply flex items-center justify-center w-10 h-10 rounded-full bg-white shadow;
+  }
+
+  .cta-btn {
+    @apply btn w-full text-lg py-3;
+  }
 }

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -1,6 +1,10 @@
-import { Link } from 'react-router-dom'
 import { useContent } from '../contexts/ContentProvider'
 import LoadingSkeleton from '../components/LoadingSkeleton'
+import NavBar from '../components/NavBar'
+import Hero from '../components/Hero'
+import ProgressStrip from '../components/ProgressStrip'
+import ThemeList from '../components/ThemeList'
+import CTAButton from '../components/CTAButton'
 
 const Home = () => {
   const { progress, loading, previousWeek } = useContent()
@@ -9,36 +13,32 @@ const Home = () => {
   const titles = ['Language', 'Math', 'Knowledge']
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen space-y-4 p-4 pt-12 text-center">
-      <h1 className="text-3xl font-bold">FlinkDink Flashcards</h1>
-      <p>
-        Week {progress.week} – Day {progress.day}
-      </p>
-      {progress.streak >= 2 && (
-        <span className="badge">🔥 {progress.streak}-day streak</span>
-      )}
-      <div className="flex gap-1" aria-label="sessions-progress">
-        {[1, 2, 3].map((n) => (
-          <span
-            key={n}
-            data-testid="session-dot"
-            className={`progress-dot${n <= completed ? ' filled' : ''}`}
-          />
-        ))}
-      </div>
-      <ul className="text-sm text-gray-600 space-y-1">
-        {titles.map((t) => (
-          <li key={t}>{t}</li>
-        ))}
-      </ul>
-      <Link to="/session" className="btn w-full">
-        Start Week {progress.week} • Day {progress.day} • Session {progress.session}
-      </Link>
-      {progress.week > 1 && (
-        <button type="button" onClick={previousWeek} className="btn">
-          ← Previous Week
-        </button>
-      )}
+    <div className="min-h-screen flex flex-col">
+      <NavBar />
+      <main className="flex flex-col items-center flex-1 p-4 space-y-8 w-full max-w-md mx-auto pt-8">
+        <Hero
+          headline="FlinkDink Flashcards"
+          tagline={`Week ${progress.week} \u2013 Day ${progress.day}`}
+        />
+        {progress.streak >= 2 && (
+          <span className="badge">🔥 {progress.streak}-day streak</span>
+        )}
+        <ProgressStrip
+          week={progress.week}
+          day={progress.day}
+          session={progress.session}
+          completedSessions={completed}
+        />
+        <ThemeList languageTheme={titles[0]} mathRange={titles[1]} knowledgeTheme={titles[2]} />
+        <CTAButton to="/session">
+          Start Week {progress.week} • Day {progress.day} • Session {progress.session}
+        </CTAButton>
+        {progress.week > 1 && (
+          <button type="button" onClick={previousWeek} className="btn">
+            ← Previous Week
+          </button>
+        )}
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement NavBar with settings button
- add Hero, ProgressStrip, ThemeList, CTAButton, and SettingsButton components
- refactor Home screen to use new components
- style icon and CTA buttons via Tailwind
- document new NavBar behavior in README
- test NavBar component

## Testing
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852bbc3d4e8832e95640bb3d0c1067f