### PR TITLE
Add dashboard route and integrate nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ random order while the upper five stay sequential.
 ## Navigation
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
+Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
 
 ## Accessibility
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Home from './screens/Home'
 import Session from './screens/Session'
+import Dashboard from './screens/Dashboard'
 import { ContentProvider } from './contexts/ContentProvider'
 import ErrorBanner from './components/ErrorBanner'
 import './App.css'
@@ -12,6 +13,7 @@ const App = () => (
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/session" element={<Session />} />
+        <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
     </ContentProvider>
   </BrowserRouter>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,16 +1,18 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import SettingsButton from './SettingsButton';
 
 const NavBar = () => {
+  const navigate = useNavigate();
   const { pathname } = useLocation();
   const isHome = pathname === '/';
+  const handleSettings = () => navigate('/dashboard');
   return (
     <nav className="sticky top-0 bg-gray-50 flex items-center p-4 z-50">
       {isHome ? (
         <>
           <div className="flex-1" />
           <span className="mx-auto font-bold text-2xl text-indigo-600">FlinkDink</span>
-          <SettingsButton />
+          <SettingsButton onClick={handleSettings} />
         </>
       ) : (
         <>
@@ -22,7 +24,7 @@ const NavBar = () => {
             🏠
           </Link>
           <div className="flex-1" />
-          <SettingsButton />
+          <SettingsButton onClick={handleSettings} />
         </>
       )}
     </nav>

--- a/src/components/NavBar.test.jsx
+++ b/src/components/NavBar.test.jsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import NavBar from './NavBar'
 
 describe('NavBar', () => {
@@ -22,5 +22,18 @@ describe('NavBar', () => {
     )
     expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument()
+  })
+
+  it('navigates to dashboard when settings clicked', () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<NavBar />} />
+          <Route path="/dashboard" element={<div>Dash</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    expect(screen.getByText('Dash')).toBeInTheDocument()
   })
 })

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useContent } from '../contexts/ContentProvider'
+import NavBar from '../components/NavBar'
 
 const PIN = '1234'
 
@@ -12,8 +13,10 @@ const Dashboard = () => {
 
   if (!unlocked) {
     return (
-      <div className="p-4 space-y-2 text-center">
-        <h1 className="text-xl font-bold">Enter PIN</h1>
+      <>
+        <NavBar />
+        <div className="p-4 space-y-2 text-center pt-20">
+          <h1 className="text-xl font-bold">Enter PIN</h1>
 
         <label htmlFor="pin" className="sr-only">PIN</label>
         <input
@@ -31,7 +34,8 @@ const Dashboard = () => {
         >
           Unlock
         </button>
-      </div>
+        </div>
+      </>
     )
   }
 
@@ -47,8 +51,10 @@ const Dashboard = () => {
 
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
+    <>
+      <NavBar />
+      <div className="p-4 space-y-4 pt-20">
+        <h1 className="text-2xl font-bold">Dashboard</h1>
       <div className="grid grid-cols-7 gap-2 text-center text-sm">
 
         {days.map((d) => (
@@ -81,7 +87,8 @@ const Dashboard = () => {
           Print Certificate
         </button>
       </div>
-    </div>
+      </div>
+    </>
   )
 }
 

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import Dashboard from './Dashboard'
 import { useContent } from '../contexts/ContentProvider'
 
@@ -12,7 +13,11 @@ describe('Dashboard', () => {
       resetAll: jest.fn(),
     })
 
-    render(<Dashboard />)
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    )
 
     fireEvent.change(screen.getByLabelText('PIN'), { target: { value: '1234' } })
     fireEvent.click(screen.getByRole('button', { name: /unlock/i }))

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useContent } from '../contexts/ContentProvider'
 import LoadingSkeleton from '../components/LoadingSkeleton'
+import Header from '../components/Header'
 import LanguageModule from '../modules/LanguageModule';
 import MathModule from '../modules/MathModule';
 import EncyclopediaModule from '../modules/EncyclopediaModule';
@@ -48,8 +49,10 @@ const Session = () => {
   const handlePrev = () => step > 0 && setStep(step - 1);
 
   return (
-    <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-6">
-      <h1 className="text-2xl font-bold">Week {progress.week} – Session</h1>
+    <>
+      <Header />
+      <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20">
+        <h1 className="text-2xl font-bold">Week {progress.week} – Session</h1>
       <h2 className="text-lg text-gray-500">{titles[step]}</h2>
 
       {step === 0 && <LanguageModule words={weekData.language} />}
@@ -73,7 +76,8 @@ const Session = () => {
           }}
         />
       )}
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/src/screens/Session.test.jsx
+++ b/src/screens/Session.test.jsx
@@ -25,4 +25,24 @@ describe('Session screen', () => {
     )
     expect(screen.getByText(/failed to load week data/i)).toBeInTheDocument()
   })
+
+  it('renders header when data loaded', () => {
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      weekData: {
+        language: ['one'],
+        mathWindowStart: 1,
+        encyclopedia: [{ image: 'a', title: 'A', fact: 'fact' }],
+      },
+      loading: false,
+      error: null,
+      completeSession: jest.fn(),
+    })
+    render(
+      <MemoryRouter>
+        <Session />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('app-header')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- navigate to new `/dashboard` route from NavBar settings button
- display progress `Header` on Session screen
- wrap Dashboard screen with NavBar
- document Dashboard in README
- add tests for NavBar routing and header rendering

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c6ad3298832e9f3e97acc85e7ef7