### PR TITLE
Rebuild home UI and fix week data loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The suite uses **Jest** alongside **React Testing Library** for component tests.
 - `src/modules` – individual learning modules (Language, Math, Encyclopedia)
 - `src/screens` – page components for the router
 - `public/weeks` – JSON data files per week
+- `src/utils/fetchWeek.js` – helper to fetch a week's JSON by number
 
 ## Progress Storage
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Home from './screens/Home'
 import Session from './screens/Session'
-import Dashboard from './screens/Dashboard'
 import { ContentProvider } from './contexts/ContentProvider'
 import ErrorBanner from './components/ErrorBanner'
 import './App.css'
@@ -13,7 +12,6 @@ const App = () => (
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/session" element={<Session />} />
-        <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
     </ContentProvider>
   </BrowserRouter>

--- a/src/components/CTAButton.jsx
+++ b/src/components/CTAButton.jsx
@@ -4,17 +4,14 @@ import { useContent } from '../contexts/ContentProvider';
 const CTAButton = () => {
   const { progress } = useContent();
   const { week, day, session } = progress;
-  const label =
-    session === 1
-      ? `Start Week ${week} • Day ${day} • Session ${session} →`
-      : `Continue Week ${week} • Day ${day} • Session ${session} →`;
+  const label = session === 1 ? 'Start' : 'Continue';
 
   return (
     <Link
       to="/session"
-      className="block w-full text-center px-5 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-2xl shadow-lg mt-6 md:mt-8 mx-4 md:mx-0 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+      className="block w-full px-5 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-2xl shadow-lg mt-6 md:mt-8 mx-4 md:mx-0 focus:outline-none focus:ring-2 focus:ring-indigo-500"
     >
-      {label}
+        {label} Week {week} · Day {day} · Session {session} →
     </Link>
   );
 };

--- a/src/components/CTAButton.test.jsx
+++ b/src/components/CTAButton.test.jsx
@@ -13,7 +13,7 @@ describe('CTAButton', () => {
         <CTAButton />
       </MemoryRouter>,
     )
-    const link = screen.getByRole('link', { name: /start week 1 • day 2 • session 1/i })
+    const link = screen.getByRole('link', { name: /start week 1 · day 2 · session 1/i })
     expect(link).toHaveAttribute('href', '/session')
   })
 
@@ -25,7 +25,7 @@ describe('CTAButton', () => {
       </MemoryRouter>,
     )
     expect(
-      screen.getByRole('link', { name: /continue week 3 • day 4 • session 2/i }),
+      screen.getByRole('link', { name: /continue week 3 · day 4 · session 2/i }),
     ).toBeInTheDocument()
   })
 })

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -4,29 +4,24 @@ import SettingsButton from './SettingsButton';
 const NavBar = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const isHome = pathname === '/';
   const handleSettings = () => navigate('/dashboard');
-  return (
-    <nav className="sticky top-0 w-full bg-gray-50 shadow-sm flex items-center px-6 py-4 z-50">
-      {isHome ? (
-        <>
-          <div className="flex-1" />
-          <span className="mx-auto font-bold text-2xl text-indigo-600">FlinkDink</span>
-          <SettingsButton onClick={handleSettings} />
-        </>
-      ) : (
-        <>
-          <Link
-            to="/"
-            aria-label="Home"
-            className="p-2 rounded-full hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          >
-            🏠
-          </Link>
-          <div className="flex-1" />
-          <SettingsButton onClick={handleSettings} />
-        </>
-      )}
+  const common = 'w-full bg-gray-50 shadow-sm px-6 py-4 flex items-center justify-between';
+  return pathname === '/' ? (
+    <nav className={common}>
+      <div className="flex-1" />
+      <span className="text-2xl font-bold text-indigo-600">FlinkDink</span>
+      <SettingsButton onClick={handleSettings} />
+    </nav>
+  ) : (
+    <nav className={common}>
+      <Link
+        to="/"
+        aria-label="Home"
+        className="p-2 rounded-full hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+      >
+        🏠
+      </Link>
+      <SettingsButton onClick={handleSettings} />
     </nav>
   );
 };

--- a/src/components/ProgressStrip.jsx
+++ b/src/components/ProgressStrip.jsx
@@ -5,7 +5,7 @@ const ProgressStrip = () => {
   const { week, day, session } = progress;
   return (
     <div className="text-center space-y-1">
-      <p className="font-semibold text-gray-700">Week {week} • Day {day} • Session {session}</p>
+      <p className="font-semibold text-gray-700">Week {week} · Day {day} · Session {session}</p>
       <div className="flex items-center justify-center space-x-1" aria-label="sessions-progress">
         {[1, 2, 3].map((n) => (
           <span
@@ -15,7 +15,6 @@ const ProgressStrip = () => {
             style={{ width: '8px', height: '8px' }}
           />
         ))}
-        <span className="text-sm text-gray-600 ml-1">{session} of 3 sessions</span>
       </div>
     </div>
   );

--- a/src/components/ProgressStrip.test.jsx
+++ b/src/components/ProgressStrip.test.jsx
@@ -10,7 +10,7 @@ describe('ProgressStrip', () => {
 
     render(<ProgressStrip />);
 
-    expect(screen.getByText('Week 1 \u2022 Day 2 \u2022 Session 3')).toBeInTheDocument();
+    expect(screen.getByText('Week 1 \u00B7 Day 2 \u00B7 Session 3')).toBeInTheDocument();
     const group = screen.getByLabelText('sessions-progress');
     expect(group).toBeInTheDocument();
 

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -5,6 +5,7 @@ import {
   useState,
   useCallback,
 } from 'react'
+import { fetchWeekData } from '../utils/fetchWeek'
 
 const PROGRESS_VERSION = 1
 const PROGRESS_KEY = 'progress-v1'
@@ -50,11 +51,8 @@ export const ContentProvider = ({ children }) => {
   const loadWeek = useCallback(async () => {
     setLoading(true)
     setError(null)
-    const id = String(progress.week).padStart(3, '0')
     try {
-      const res = await fetch(`/weeks/week${id}.json`)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data = await res.json()
+      const data = await fetchWeekData(progress.week)
       setWeekData(data)
     } catch (err) {
       console.error('Failed to load week data', err)

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -8,7 +8,7 @@ export default function Home() {
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
       <NavBar />
-      <main className="flex-grow flex flex-col items-center justify-center space-y-8 w-11/12 md:w-4/5 lg:max-w-md mx-auto">
+      <main className="flex-grow flex flex-col items-center justify-center space-y-8 max-w-md w-11/12 md:w-4/5 mx-auto">
         <Hero />
         <ProgressStrip />
         <ThemeList />

--- a/src/screens/Home.test.jsx
+++ b/src/screens/Home.test.jsx
@@ -27,11 +27,11 @@ describe('Home screen', () => {
       screen.getByRole('heading', { name: /flinkdink flashcards/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText('Week 2 \u2022 Day 3 \u2022 Session 2'),
+      screen.getByText('Week 2 \u00B7 Day 3 \u00B7 Session 2'),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /continue week 2 • day 3 • session 2/i }),
+      screen.getByRole('link', { name: /continue week 2 · day 3 · session 2/i }),
     ).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(3);
   });

--- a/src/utils/fetchWeek.js
+++ b/src/utils/fetchWeek.js
@@ -1,0 +1,8 @@
+export async function fetchWeekData(week) {
+  const id = String(week).padStart(3, '0');
+  const res = await fetch(`/weeks/week${id}.json`);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- load week JSON via new `fetchWeekData()` helper
- simplify router to just Home and Session
- rebuild navbar and buttons for new bullet style
- update tests to expect the new UI
- document `fetchWeek.js`

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852cca37f94832ea4c4e0f4a61d9609