### PR TITLE
Add week navigation to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ random order while the upper five stay sequential.
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
+Parents can also jump to any of the 52 weeks from the Dashboard. Selecting a week loads its curriculum or displays "empty" if no data exists.
 
 ## Accessibility
 

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -99,6 +99,12 @@ export const ContentProvider = ({ children }) => {
     }
   }
 
+  const jumpToWeek = (week) => {
+    if (week >= 1 && week <= 52) {
+      saveProgress({ week, day: 1, session: 1 })
+    }
+  }
+
   const resetToday = () => {
     saveProgress({ ...progress, session: 1 })
   }
@@ -117,6 +123,7 @@ export const ContentProvider = ({ children }) => {
       completeSession,
       loadWeek,
       previousWeek,
+      jumpToWeek,
       resetToday,
       resetAll,
     }}

--- a/src/contexts/ContentProvider.test.jsx
+++ b/src/contexts/ContentProvider.test.jsx
@@ -123,6 +123,44 @@ describe('previousWeek', () => {
   })
 })
 
+describe('jumpToWeek', () => {
+  const JumpConsumer = () => {
+    const { progress, jumpToWeek } = useContent()
+    return (
+      <div>
+        <span data-testid="week">{progress.week}</span>
+        <span data-testid="day">{progress.day}</span>
+        <span data-testid="session">{progress.session}</span>
+        <button type="button" onClick={() => jumpToWeek(4)}>
+          jump
+        </button>
+      </div>
+    )
+  }
+
+  it('jumps to given week and resets progress', () => {
+    localStorage.setItem(
+      'progress-v1',
+      JSON.stringify({ version: 1, week: 2, day: 3, session: 2 }),
+    )
+
+    render(
+      <ContentProvider>
+        <JumpConsumer />
+      </ContentProvider>,
+    )
+
+    fireEvent.click(screen.getByText('jump'))
+    expect(screen.getByTestId('week')).toHaveTextContent('4')
+    expect(screen.getByTestId('day')).toHaveTextContent('1')
+    expect(screen.getByTestId('session')).toHaveTextContent('1')
+    const stored = JSON.parse(localStorage.getItem('progress-v1'))
+    expect(stored.week).toBe(4)
+    expect(stored.day).toBe(1)
+    expect(stored.session).toBe(1)
+  })
+})
+
 describe('reset helpers', () => {
   it('resetToday sets session to 1', () => {
     localStorage.setItem(

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -8,7 +8,15 @@ const Dashboard = () => {
   const [entered, setEntered] = useState('')
   const [unlocked, setUnlocked] = useState(false)
 
-  const { progress, resetToday, resetAll } = useContent()
+  const {
+    progress,
+    weekData,
+    loading,
+    error,
+    jumpToWeek,
+    resetToday,
+    resetAll,
+  } = useContent()
 
 
   if (!unlocked) {
@@ -42,6 +50,7 @@ const Dashboard = () => {
 
   const days = Array.from({ length: 7 }, (_, i) => i + 1)
   const modules = ['L', 'M', 'E']
+  const weeks = Array.from({ length: 52 }, (_, i) => i + 1)
 
   const isComplete = (day, modIndex) => {
     if (day < progress.day) return true
@@ -73,6 +82,30 @@ const Dashboard = () => {
           </div>
         ))}
       </div>
+      <h2 className="text-xl font-semibold pt-4">Weeks</h2>
+      <div className="grid grid-cols-13 gap-1 text-center" data-testid="week-grid">
+        {weeks.map((w) => (
+          <button
+            key={w}
+            type="button"
+            data-testid={`week-btn-${w}`}
+            className={`border p-1 rounded ${w === progress.week ? 'bg-indigo-200' : ''}`}
+            onClick={() => jumpToWeek(w)}
+          >
+            {w}
+          </button>
+        ))}
+      </div>
+      {loading && <p>Loading...</p>}
+      {!loading && error && <p className="text-red-600">Failed to load</p>}
+      {!loading && !error && !weekData && <p>empty</p>}
+      {!loading && weekData && (
+        <div className="pt-2 text-sm" data-testid="week-info">
+          <div>Language: {weekData.language.slice(0, 3).join(', ')}</div>
+          <div>Math start: {weekData.mathWindowStart}</div>
+          <div>Cards: {weekData.encyclopedia.length}</div>
+        </div>
+      )}
       <div className="space-x-2">
         <button type="button" onClick={resetToday} className="btn">
           Reset Today

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -11,6 +11,10 @@ describe('Dashboard', () => {
       progress: { week: 1, day: 2, session: 2 },
       resetToday: jest.fn(),
       resetAll: jest.fn(),
+      weekData: null,
+      loading: false,
+      error: null,
+      jumpToWeek: jest.fn(),
     })
 
     render(
@@ -29,5 +33,31 @@ describe('Dashboard', () => {
     // day 2 first module complete only
     expect(screen.getByTestId('day2-module0')).toHaveClass('bg-green-400')
     expect(screen.getByTestId('day2-module1')).toHaveClass('bg-gray-200')
+  })
+
+  it('shows week buttons and jumps to week', () => {
+    const jumpToWeek = jest.fn()
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      resetToday: jest.fn(),
+      resetAll: jest.fn(),
+      weekData: null,
+      loading: false,
+      error: null,
+      jumpToWeek,
+    })
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByLabelText('PIN'), { target: { value: '1234' } })
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }))
+
+    expect(screen.getByTestId('week-btn-10')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('week-btn-10'))
+    expect(jumpToWeek).toHaveBeenCalledWith(10)
   })
 })


### PR DESCRIPTION
## Summary
- allow jumping to any week via `jumpToWeek` in ContentProvider
- display 52 week buttons on dashboard with preview of week data
- add tests for week jumping logic
- document week jumping feature in README

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852f8b04630832ebbf6eb17e4d2a868