### PR TITLE
Add VITE_API_BASE_URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+PORT=3001
+JWT_SECRET=your-secret
+DB_PATH=./users.db
+VITE_API_BASE_URL=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -124,11 +124,16 @@ Create a `.env` file in the project root with the following variables:
 PORT=3001
 JWT_SECRET=your-secret
 DB_PATH=./users.db
+VITE_API_BASE_URL=http://localhost:3001
 ```
 
 The default credentials are **demo@example.com** / **password**. You can also
 register a new account using the **Sign Up** page. Successful authentication
 returns a token stored in `localStorage` by the `AuthProvider`.
+
+During development the API server runs on `http://localhost:3001`, so the
+`VITE_API_BASE_URL` variable should point there. For production builds set it to
+the full URL of your deployed API server.
 
 ## Mobile Usage
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
   transform: {
     '^.+\\.[jt]sx?$': ['@swc/jest'],
   },
+  extensionsToTreatAsEsm: ['.jsx'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -11,8 +11,13 @@ const AUTH_KEY = 'auth-token';
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem(AUTH_KEY));
 
+  const baseUrl =
+    (import.meta.env && import.meta.env.VITE_API_BASE_URL) ||
+    process.env.VITE_API_BASE_URL ||
+    '';
+
   const login = async (email, password) => {
-    const res = await fetch('/api/login', {
+    const res = await fetch(`${baseUrl}/api/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),
@@ -28,7 +33,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   const register = async (email, password) => {
-    const res = await fetch('/api/register', {
+    const res = await fetch(`${baseUrl}/api/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),

--- a/src/contexts/AuthProvider.test.jsx
+++ b/src/contexts/AuthProvider.test.jsx
@@ -1,0 +1,55 @@
+import { render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { AuthProvider, useAuth } from './AuthProvider';
+
+const Caller = ({ action }) => {
+  const auth = useAuth();
+  useEffect(() => {
+    action(auth);
+  }, [auth, action]);
+  return null;
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete global.fetch;
+  delete process.env.VITE_API_BASE_URL;
+});
+
+describe('AuthProvider base URL', () => {
+  test('login uses configured base URL', async () => {
+    process.env.VITE_API_BASE_URL = 'http://test';
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 't' }),
+    });
+    global.fetch = fetchMock;
+
+    render(
+      <AuthProvider>
+        <Caller action={({ login }) => login('a', 'b')} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toBe('http://test/api/login');
+  });
+
+  test('register uses configured base URL', async () => {
+    process.env.VITE_API_BASE_URL = 'http://test';
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 't' }),
+    });
+    global.fetch = fetchMock;
+
+    render(
+      <AuthProvider>
+        <Caller action={({ register }) => register('a', 'b')} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toBe('http://test/api/register');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-})
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    define: {
+      'import.meta.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- load environment variables in vite config so VITE_API_BASE_URL is available
- document the new variable in README and provide sample `.env.example`
- update AuthProvider to prefix auth requests with the configured base url
- cover base url logic with new AuthProvider unit tests

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685302ccea84832eabc2d4b84ac279be