### PR TITLE
Responsive week grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Math practice screens now size their dot container responsively using
 `h-[60vw] sm:h-[300px]`. Dots are positioned with a new algorithm that retries
 until each one is at least eight percent away from the others, preventing
 overlap on small displays.
+The Dashboard now uses a responsive week grid that shows seven columns on small
+screens and thirteen on larger displays.
 
 ### Build for Android or iOS
 

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -83,7 +83,7 @@ const Dashboard = () => {
         ))}
       </div>
       <h2 className="text-xl font-semibold pt-4">Weeks</h2>
-      <div className="grid grid-cols-13 gap-1 text-center" data-testid="week-grid">
+      <div className="grid grid-cols-7 sm:grid-cols-13 gap-1 text-center" data-testid="week-grid">
         {weeks.map((w) => (
           <button
             key={w}

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -65,4 +65,31 @@ describe('Dashboard', () => {
     fireEvent.click(screen.getByTestId('week-btn-10'))
     expect(jumpToWeek).toHaveBeenCalledWith(10)
   })
+
+  it('uses responsive classes for week grid', () => {
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      resetToday: jest.fn(),
+      resetAll: jest.fn(),
+      weekData: null,
+      loading: false,
+      error: null,
+      jumpToWeek: jest.fn(),
+    })
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Dashboard />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByLabelText('PIN'), { target: { value: '1234' } })
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }))
+
+    expect(screen.getByTestId('week-grid')).toHaveClass(
+      'grid grid-cols-7 sm:grid-cols-13 gap-1 text-center',
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- show 7 columns for week grid on small screens
- test week grid responsive classes
- document improved mobile layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685318f64a08832e83463797bef8c8b5