### PR TITLE
Improve Dashboard input responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ overlap on small displays.
 The Dashboard now uses a responsive week grid that shows seven columns on small
 screens and thirteen on larger displays. The carousel height now uses
 `min-h-[50vh]` and login/signup forms are `w-full max-w-xs` so they fit on
-narrow devices.
+narrow devices. The PIN input on the Dashboard also uses these classes so it
+stretches across narrow screens without exceeding `max-w-xs`.
 
 Full-screen areas leverage viewport units so layouts adapt to device height.
 The math board scales with the viewport width while carousels always take up at

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -31,7 +31,7 @@ const Dashboard = () => {
           id="pin"
 
           type="password"
-          className="border p-2"
+          className="border p-2 w-full max-w-xs"
           value={entered}
           onChange={(e) => setEntered(e.target.value)}
         />

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -7,6 +7,29 @@ import { useContent } from '../contexts/ContentProvider'
 jest.mock('../contexts/ContentProvider')
 
 describe('Dashboard', () => {
+  it('PIN input uses responsive width classes', () => {
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      resetToday: jest.fn(),
+      resetAll: jest.fn(),
+      weekData: null,
+      loading: false,
+      error: null,
+      jumpToWeek: jest.fn(),
+    })
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Dashboard />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    const input = screen.getByLabelText('PIN')
+    expect(input).toHaveClass('w-full')
+    expect(input).toHaveClass('max-w-xs')
+  })
   it('unlocks with PIN and shows progress grid', () => {
     useContent.mockReturnValue({
       progress: { week: 1, day: 2, session: 2 },


### PR DESCRIPTION
## Summary
- apply responsive width classes to PIN input
- test for responsive classes on the Dashboard input
- mention new responsive PIN input in the Mobile Usage docs

## Testing
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx jest src/screens/Dashboard.test.jsx` *(fails: ReferenceError: jest is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685393c3ec08832eac310acc2bf3338f