### PR TITLE
Update encyclopedia module image styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ screens and thirteen on larger displays. The carousel height now uses
 `min-h-[50vh]` and login/signup forms are `w-full max-w-xs` so they fit on
 narrow devices. The PIN input on the Dashboard also uses these classes so it
 stretches across narrow screens without exceeding `max-w-xs`.
+Encyclopedia images now use `h-48 sm:h-64` so photos scale down on mobile devices.
 
 Full-screen areas leverage viewport units so layouts adapt to device height.
 The math board scales with the viewport width while carousels always take up at

--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -9,7 +9,12 @@ const EncyclopediaModule = ({ cards }) => {
       items={items}
       renderItem={(card) => (
         <div className="space-y-2">
-          <img loading="lazy" src={card.image} alt={card.title} className="w-full h-64 object-cover rounded-xl" />
+          <img
+            loading="lazy"
+            src={card.image}
+            alt={card.title}
+            className="w-full h-48 sm:h-64 object-cover rounded-xl"
+          />
           <h3 className="text-xl font-bold">{card.title}</h3>
           <p className="text-gray-600">{card.fact}</p>
         </div>

--- a/src/modules/EncyclopediaModule.test.jsx
+++ b/src/modules/EncyclopediaModule.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import EncyclopediaModule from './EncyclopediaModule';
+
+// Verify the image uses responsive height classes and includes an alt attribute
+
+describe('EncyclopediaModule', () => {
+  it('renders images with responsive classes and alt text', () => {
+    const cards = [
+      {
+        image: '/images/test.svg',
+        title: 'Test Card',
+        fact: 'A fact',
+      },
+    ];
+    render(<EncyclopediaModule cards={cards} />);
+    const img = screen.getByRole('img', { name: 'Test Card' });
+    expect(img).toHaveAttribute('alt', 'Test Card');
+    expect(img).toHaveClass('w-full', 'h-48', 'sm:h-64', 'object-cover', 'rounded-xl');
+  });
+});


### PR DESCRIPTION
## Summary
- adjust encyclopedia image height using `h-48 sm:h-64`
- test that encyclopedia images include alt text and responsive classes
- document responsive image height in mobile layout notes

## Testing
- `npm run lint`
- `npx jest src/modules/EncyclopediaModule.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_685394e204e4832eb8e98f22d5c6976d