### PR TITLE
Update math dot color style

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Math practice screens now size their dot container responsively using
 `h-[60vw] sm:h-[40vh]`. Dots are positioned with a new algorithm that retries
 until each one is at least eight percent away from the others, preventing
 overlap on small displays.
-Red dots specify their width and height inline so builds without Tailwind still
-display them correctly.
+Red dots specify their width, height and color inline so builds without
+Tailwind still display them correctly.
 The Dashboard now uses a responsive week grid that shows seven columns on small
 screens and thirteen on larger displays. The carousel height now uses
 `min-h-[50vh]` and login/signup forms are `w-full max-w-xs` so they fit on

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -25,12 +25,13 @@ const MathModule = ({ start }) => {
             {positions.map((pos, i) => (
               <span
                 key={i}
-                className="absolute inline-block rounded-full bg-red-500"
+                className="absolute inline-block rounded-full"
                 style={{
                   width: '1rem',
                   height: '1rem',
                   top: pos.top,
                   left: pos.left,
+                  backgroundColor: '#ef4444',
                 }}
               />
             ))}

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -18,6 +18,7 @@ describe('MathModule', () => {
       const computed = getComputedStyle(dot);
       expect(parseFloat(computed.width)).toBeGreaterThan(0);
       expect(parseFloat(computed.height)).toBeGreaterThan(0);
+      expect(dot.style.backgroundColor).not.toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary
- style math dots inline with color instead of using a class
- test for inline background color
- document inline dot color in Mobile Usage section

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853bc9f7a18832e81ab2f9e4ea6c709