### PR TITLE
Add dashboard progress header

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ random order while the upper five stay sequential.
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
 Parents can also jump to any of the 52 weeks from the Dashboard. Selecting a week loads its curriculum or displays "empty" if no data exists.
+When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.
 
 ## Accessibility
 

--- a/src/components/DashboardHeader.jsx
+++ b/src/components/DashboardHeader.jsx
@@ -1,0 +1,20 @@
+import ProgressStrip from './ProgressStrip';
+import { useContent } from '../contexts/ContentProvider';
+
+const DashboardHeader = () => {
+  const { progress } = useContent();
+  const { week, day, session, streak } = progress;
+  return (
+    <div className="text-center space-y-2">
+      <h1 className="text-3xl font-bold">
+        Week {week} · Day {day} · Session {session}
+      </h1>
+      <ProgressStrip />
+      <p className="text-lg font-semibold" data-testid="streak">
+        Streak: {streak}
+      </p>
+    </div>
+  );
+};
+
+export default DashboardHeader;

--- a/src/components/DashboardHeader.test.jsx
+++ b/src/components/DashboardHeader.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import DashboardHeader from './DashboardHeader';
+import { useContent } from '../contexts/ContentProvider';
+
+jest.mock('../contexts/ContentProvider');
+
+describe('DashboardHeader', () => {
+  it('shows progress values and session dots', () => {
+    useContent.mockReturnValue({ progress: { week: 2, day: 3, session: 1, streak: 4 } });
+
+    render(<DashboardHeader />);
+
+    expect(screen.getAllByText('Week 2 \u00B7 Day 3 \u00B7 Session 1')).toHaveLength(2);
+    expect(screen.getByTestId('streak')).toHaveTextContent('Streak: 4');
+
+    const dots = screen.getAllByTestId('session-dot');
+    expect(dots).toHaveLength(3);
+    const filled = dots.filter((d) => d.classList.contains('bg-indigo-600'));
+    expect(filled).toHaveLength(1);
+  });
+});

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useContent } from '../contexts/ContentProvider'
 import NavBar from '../components/NavBar'
+import DashboardHeader from '../components/DashboardHeader'
 
 const PIN = '1234'
 
@@ -62,6 +63,7 @@ const Dashboard = () => {
   return (
     <>
       <NavBar />
+      <DashboardHeader />
       <div className="p-4 space-y-4 pt-20">
         <h1 className="text-2xl font-bold">Dashboard</h1>
       <div className="grid grid-cols-7 gap-2 text-center text-sm">


### PR DESCRIPTION
## Summary
- add `DashboardHeader` component using `ProgressStrip`
- show header in `Dashboard` when unlocked
- test `DashboardHeader`
- document the dashboard header in README

## Testing
- `npm test`
- `npx jest src/components/DashboardHeader.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6853bea10c0c832ea98489710176435a