### PR TITLE
Replace dashboard grid with semantic table

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The application now uses a `NavBar` component on the home screen. It shows a bac
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
 Parents can also jump to any of the 52 weeks from the Dashboard. Selecting a week loads its curriculum or displays "empty" if no data exists.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.
+Daily modules are listed in a small table labelled **"Weekly progress"**, where completed cells appear green.
 
 ## Accessibility
 

--- a/src/index.css
+++ b/src/index.css
@@ -89,9 +89,15 @@
   .bounce-toast {
     animation: bounce 1s;
   }
-@media (prefers-reduced-motion: reduce) {
+  @media (prefers-reduced-motion: reduce) {
     .bounce-toast {
       animation: none;
     }
+  }
+
+  .progress-table th,
+  .progress-table td {
+    padding: 0.25rem;
+    border: 1px solid rgb(209 213 219); /* tailwind gray-300 */
   }
 }

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -66,24 +66,30 @@ const Dashboard = () => {
       <DashboardHeader />
       <div className="p-4 space-y-4 pt-20">
         <h1 className="text-2xl font-bold">Dashboard</h1>
-      <div className="grid grid-cols-7 gap-2 text-center text-sm">
-
-        {days.map((d) => (
-          <div key={d} className="border p-2 space-y-1">
-            <div className="font-bold">Day {d}</div>
-            {modules.map((m, i) => (
-              <div
-                key={i}
-                className={`h-4 ${isComplete(d, i) ? 'bg-green-400' : 'bg-gray-200'}`}
-                data-testid={`day${d}-module${i}`}
-              >
-                {m}
-              </div>
+      <table className="progress-table w-full text-center text-xs" aria-label="Weekly progress">
+        <thead>
+          <tr>
+            {days.map((d) => (
+              <th key={d}>Day {d}</th>
             ))}
-
-          </div>
-        ))}
-      </div>
+          </tr>
+        </thead>
+        <tbody>
+          {modules.map((m, i) => (
+            <tr key={m}>
+              {days.map((d) => (
+                <td
+                  key={d}
+                  className={isComplete(d, i) ? 'bg-green-400' : 'bg-gray-200'}
+                  data-testid={`day${d}-module${i}`}
+                >
+                  {m}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
       <h2 className="text-xl font-semibold pt-4">Weeks</h2>
       <div className="grid grid-cols-7 sm:grid-cols-13 gap-1 text-center" data-testid="week-grid">
         {weeks.map((w) => (

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -30,7 +30,7 @@ describe('Dashboard', () => {
     expect(input).toHaveClass('w-full')
     expect(input).toHaveClass('max-w-xs')
   })
-  it('unlocks with PIN and shows progress grid', () => {
+  it('unlocks with PIN and shows progress table', () => {
     useContent.mockReturnValue({
       progress: { week: 1, day: 2, session: 2 },
       resetToday: jest.fn(),
@@ -53,6 +53,7 @@ describe('Dashboard', () => {
     fireEvent.click(screen.getByRole('button', { name: /unlock/i }))
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByRole('table', { name: /weekly progress/i })).toBeInTheDocument()
     // day 1 modules are all complete
     expect(screen.getByTestId('day1-module0')).toHaveClass('bg-green-400')
     expect(screen.getByTestId('day1-module2')).toHaveClass('bg-green-400')


### PR DESCRIPTION
## Summary
- replace grid layout on Dashboard with a semantic table
- style table cells and add new progress-table class
- test table rendering and cell colors
- document the Weekly progress table in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c02300ac832eb39ef5c6e8536d5c