### PR TITLE
Improve Dashboard week selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,12 @@ overlap on small displays.
 Red dots specify their width, height and color inline so builds without
 Tailwind still display them correctly.
 The Dashboard now uses a responsive week grid that shows seven columns on small
-screens and thirteen on larger displays. The carousel height now uses
-`min-h-[50vh]` and login/signup forms are `w-full max-w-xs` so they fit on
-narrow devices. The PIN input on the Dashboard also uses these classes so it
-stretches across narrow screens without exceeding `max-w-xs`.
+screens and thirteen on larger displays. Each week button has a subtle hover
+state, and the active week appears in bold with `aria-current="true"` for
+accessibility. The carousel height now uses `min-h-[50vh]` and login/signup
+forms are `w-full max-w-xs` so they fit on narrow devices. The PIN input on the
+Dashboard also uses these classes so it stretches across narrow screens without
+exceeding `max-w-xs`.
 Encyclopedia images now use `h-48 sm:h-64` so photos scale down on mobile devices.
 
 Full-screen areas leverage viewport units so layouts adapt to device height.

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -97,7 +97,8 @@ const Dashboard = () => {
             key={w}
             type="button"
             data-testid={`week-btn-${w}`}
-            className={`border p-1 rounded ${w === progress.week ? 'bg-indigo-200' : ''}`}
+            className={`border p-1 rounded hover:bg-indigo-100 ${w === progress.week ? 'bg-indigo-200 font-bold' : ''}`}
+            aria-current={w === progress.week ? 'true' : undefined}
             onClick={() => jumpToWeek(w)}
           >
             {w}

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -117,6 +117,34 @@ describe('Dashboard', () => {
     )
   })
 
+  it('marks active week button and includes hover class', () => {
+    useContent.mockReturnValue({
+      progress: { week: 3, day: 1, session: 1 },
+      resetToday: jest.fn(),
+      resetAll: jest.fn(),
+      weekData: null,
+      loading: false,
+      error: null,
+      jumpToWeek: jest.fn(),
+    })
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Dashboard />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByLabelText('PIN'), { target: { value: '1234' } })
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }))
+
+    const active = screen.getByTestId('week-btn-3')
+    expect(active).toHaveAttribute('aria-current', 'true')
+    expect(active).toHaveClass('font-bold')
+    expect(active).toHaveClass('hover:bg-indigo-100')
+  })
+
   it('renders control buttons with emoji labels', () => {
     useContent.mockReturnValue({
       progress: { week: 1, day: 1, session: 1 },


### PR DESCRIPTION
## Summary
- highlight active week in Dashboard
- ensure active week has aria-current and hover state tests
- document week selector behavior in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853c24a4870832eb1417bc59380d6cb