### PR TITLE
Add Unsplash photo fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ the API routes, while React components rely on **React Testing Library**.
 - `src/screens` – page components for the router
 - `public/weeks` – JSON data files per week
 - `src/utils/fetchWeek.js` – helper to fetch a week's JSON by number
+- `src/utils/fetchPhoto.js` – fetches an Unsplash image for a given query
  - Language words now display in a very large lowercase font so toddlers
    can easily read them
 

--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -1,9 +1,38 @@
+import { useEffect, useState } from 'react'
 import Carousel from '../components/Carousel'
+import { fetchPhoto } from '../utils/fetchPhoto'
 
 const shuffle = (arr) => [...arr].sort(() => Math.random() - 0.5)
 
 const EncyclopediaModule = ({ cards }) => {
-  const items = shuffle(cards)
+  const [items, setItems] = useState(() => shuffle(cards))
+
+  useEffect(() => {
+    const shuffled = shuffle(cards)
+    setItems(shuffled)
+
+    let active = true
+    shuffled.forEach((card, index) => {
+      fetchPhoto(card.title)
+        .then((url) => {
+          if (active) {
+            setItems((prev) => {
+              const next = [...prev]
+              next[index] = { ...next[index], image: url }
+              return next
+            })
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to fetch image', err)
+        })
+    })
+
+    return () => {
+      active = false
+    }
+  }, [cards])
+
   return (
     <Carousel
       items={items}

--- a/src/modules/EncyclopediaModule.test.jsx
+++ b/src/modules/EncyclopediaModule.test.jsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import EncyclopediaModule from './EncyclopediaModule';
+import { render, screen, waitFor } from '@testing-library/react'
+import EncyclopediaModule from './EncyclopediaModule'
 
 // Verify the image uses responsive height classes and includes an alt attribute
 
@@ -17,4 +17,29 @@ describe('EncyclopediaModule', () => {
     expect(img).toHaveAttribute('alt', 'Test Card');
     expect(img).toHaveClass('w-full', 'h-48', 'sm:h-64', 'object-cover', 'rounded-xl');
   });
+
+  it('fetches remote photos and replaces defaults', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://img.test/photo.jpg' }),
+    })
+    global.fetch = fetchMock
+    globalThis.fetch = fetchMock
+    if (typeof window !== 'undefined') {
+      window.fetch = fetchMock
+    }
+
+    const cards = [
+      { image: '/images/test.svg', title: 'Lion', fact: 'King' },
+    ]
+    render(<EncyclopediaModule cards={cards} />)
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith('/api/photos?query=Lion'),
+    )
+    const img = screen.getByRole('img', { name: 'Lion' })
+    await waitFor(() =>
+      expect(img).toHaveAttribute('src', 'https://img.test/photo.jpg'),
+    )
+  })
 });

--- a/src/utils/fetchPhoto.js
+++ b/src/utils/fetchPhoto.js
@@ -1,0 +1,11 @@
+export async function fetchPhoto(query) {
+  const baseUrl = process.env.VITE_API_BASE_URL || ''
+  const res = await fetch(`${baseUrl}/api/photos?query=${encodeURIComponent(query)}`);
+  if (!res.ok) {
+    const message = await res.text();
+    console.error('Photo fetch failed', message);
+    throw new Error(message || `HTTP ${res.status}`);
+  }
+  const data = await res.json();
+  return data.url;
+}


### PR DESCRIPTION
## Summary
- create `fetchPhoto` utility to grab URLs from `/api/photos`
- update `EncyclopediaModule` to load remote images on mount
- test Unsplash image replacement logic
- document new util in README

## Testing
- `npm run lint`
- `npm test`
- `npx jest src/modules/EncyclopediaModule.test.jsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6853c9be8da4832eb301919d3b26d9c4