### PR TITLE
Improve Unsplash error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ the full URL of your deployed API server.
 
 `GET /api/photos?query=term` searches Unsplash and returns the first image URL.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. A failed Unsplash
-request responds with `{ "detail": "Unsplash request failed" }` and the status
-code from the Unsplash API.
+request responds with `{ "detail": "Unsplash request failed", "error": "message" }`,
+where the `error` field contains either the Unsplash response text or the network
+error message.
 
 ### Interpreting Server Logs
 

--- a/server.js
+++ b/server.js
@@ -86,8 +86,11 @@ app.get('/api/photos', async (req, res) => {
       },
     });
     if (!response.ok) {
-      console.error('Unsplash error', await response.text());
-      res.status(response.status).json({ detail: 'Unsplash request failed' });
+      const errorText = await response.text();
+      console.error('Unsplash error', errorText);
+      res
+        .status(response.status)
+        .json({ detail: 'Unsplash request failed', error: errorText });
       return;
     }
     const data = await response.json();
@@ -98,7 +101,7 @@ app.get('/api/photos', async (req, res) => {
     res.json({ url: data.results[0].urls.small });
   } catch (err) {
     console.error('Fetch to Unsplash failed', err);
-    res.status(502).json({ detail: 'Unsplash request failed' });
+    res.status(502).json({ detail: 'Unsplash request failed', error: err.message });
   }
 });
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -88,5 +88,6 @@ describe('photo endpoint', () => {
 
     expect(res.status).toBe(503);
     expect(res.body.detail).toBe('Unsplash request failed');
+    expect(res.body.error).toBe('Error');
   });
 });


### PR DESCRIPTION
## Summary
- include error details when the Unsplash API request fails
- expose the error message in the test expectations
- document the updated photo search API response

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853dc38b694832ea19a99ce2a2c7f6d