### PR TITLE
Improve fetchPhoto error handling with placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ returns a token stored in `localStorage` by the `AuthProvider`.
 During development the API server runs on `http://localhost:3001`, so the
 `VITE_API_BASE_URL` variable should point there. For production builds set it to
 the full URL of your deployed API server.
+The frontend reads this value via the `__API_BASE_URL__` constant defined by Vite.
 
 ### Photo Search API
 
@@ -152,6 +153,7 @@ The server requires `UNSPLASH_ACCESS_KEY` in the environment. A failed Unsplash
 request responds with `{ "detail": "Unsplash request failed", "error": "message" }`,
 where the `error` field contains either the Unsplash response text or the network
 error message.
+If the request fails on the client, the app falls back to `/images/placeholder.png`. The file is not included in the repo; add your own placeholder image at `public/images/placeholder.png`.
 
 ### Interpreting Server Logs
 

--- a/server.js
+++ b/server.js
@@ -78,6 +78,7 @@ app.get('/api/photos', async (req, res) => {
     res.status(400).json({ detail: 'Missing query parameter' });
     return;
   }
+  res.set('Cache-Control', 'no-store');
   try {
     const url = `${UNSPLASH_URL}?query=${encodeURIComponent(query)}&per_page=1`;
     const response = await fetch(url, {

--- a/src/utils/fetchPhoto.js
+++ b/src/utils/fetchPhoto.js
@@ -1,17 +1,28 @@
+/* global __API_BASE_URL__ */
 export async function fetchPhoto(query) {
-  // Vite injects environment variables via `import.meta.env` in the browser.
-  // During Jest tests or Node usage `import.meta` is undefined, so fall back to
-  // `process.env` to keep the function working in all environments.
+  // `__API_BASE_URL__` is replaced by Vite during the build. Jest and Node
+  // fall back to `process.env` when the global constant is undefined.
   const baseUrl =
-    (typeof import.meta !== 'undefined' && import.meta.env.VITE_API_BASE_URL) ||
+    (typeof __API_BASE_URL__ !== 'undefined' && __API_BASE_URL__) ||
     process.env.VITE_API_BASE_URL ||
-    ''
-  const res = await fetch(`${baseUrl}/api/photos?query=${encodeURIComponent(query)}`);
-  if (!res.ok) {
-    const message = await res.text();
-    console.error('Photo fetch failed', message);
-    throw new Error(message || `HTTP ${res.status}`);
+    '';
+
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/photos?query=${encodeURIComponent(query)}`,
+    );
+    const body = await res.text();
+    console.log('Unsplash status', res.status);
+    console.log('Unsplash body', body);
+
+    if (!res.ok) {
+      return '/images/placeholder.png';
+    }
+
+    const data = JSON.parse(body);
+    return data.url || '/images/placeholder.png';
+  } catch (err) {
+    console.error('Photo fetch failed', err);
+    return '/images/placeholder.png';
   }
-  const data = await res.json();
-  return data.url;
 }

--- a/tests/fetchPhoto.test.js
+++ b/tests/fetchPhoto.test.js
@@ -1,0 +1,39 @@
+let fetchPhoto
+
+beforeAll(async () => {
+  ;({ fetchPhoto } = await import('../src/utils/fetchPhoto.js'))
+})
+
+describe('fetchPhoto', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete global.fetch
+  })
+
+  test('returns URL on success', async () => {
+    const url = 'http://img.test/photo.jpg'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ url }),
+    })
+
+    await expect(fetchPhoto('cats')).resolves.toBe(url)
+  })
+
+  test('returns placeholder on 404', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => 'Not found',
+    })
+
+    await expect(fetchPhoto('cats')).resolves.toBe('/images/placeholder.png')
+  })
+
+  test('returns placeholder on network error', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail'))
+
+    await expect(fetchPhoto('cats')).resolves.toBe('/images/placeholder.png')
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     define: {
       'import.meta.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
+      __API_BASE_URL__: JSON.stringify(env.VITE_API_BASE_URL),
       'import.meta.env.VITE_UNSPLASH_ACCESS_KEY': JSON.stringify(env.UNSPLASH_ACCESS_KEY),
       'import.meta.env.VITE_UNSPLASH_SECRET_KEY': JSON.stringify(env.UNSPLASH_SECRET_KEY),
     },


### PR DESCRIPTION
## Summary
- return placeholder image when Unsplash fetch fails
- disable caching for `/api/photos` responses
- expose `__API_BASE_URL__` constant via Vite
- document placeholder behaviour in README
- add unit tests for `fetchPhoto`
- **remove placeholder.png file**

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853e2f4fbf4832ea0362691f26010c0