### PR TITLE
Fix Afrikaans breed queries

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,9 +12,27 @@ const UNSPLASH_URL = 'https://api.unsplash.com/search/photos';
 // return matching results. The search terms are almost entirely in English,
 // so Afrikaans queries often yield a 404 response.
 export const breedMap = {
-  Jagwindhond: 'greyhound',
-  'Engelse Patryshond': 'English pointer',
+  // Dogs
+  'Afgaanse hond': 'Afghan hound',
   'Goudkleurige Apporteerhond': 'Golden Retriever',
+  'Dalmatiese hond': 'Dalmatian',
+  Dashond: 'Dachshund',
+  'Franse Dashond': 'Basset Hound',
+  Jagwindhond: 'greyhound',
+  Bulhond: 'Bulldog',
+  'Engelse Patryshond': 'English pointer',
+  Bloedhond: 'Bloodhound',
+  'Rhodesiese Rifrughond': 'Rhodesian Ridgeback',
+  // Cats (week 2)
+  'Rob bruin Himalajan kat': 'Himalayan cat',
+  'Siamese kat': 'Siamese cat',
+  'Turkse Van kat': 'Turkish Van cat',
+  'Chinchilla kat': 'Chinchilla cat',
+  'Rooi Persiese kat': 'Red Persian cat',
+  'Rokerige Swart Persiese kat': 'Smoky black Persian cat',
+  'Turkse Angora kat': 'Turkish Angora cat',
+  'Abbesini\u00e9r kat': 'Abyssinian cat',
+  'Ragdoll kat': 'Ragdoll cat',
 };
 
 dotenv.config();


### PR DESCRIPTION
## Summary
- map Afrikaans breed names to English equivalents so Unsplash gets valid queries
- expand server test coverage for multiple breed translations

## Testing
- `npm test`
- `npx eslint . --ext js,jsx`

------
https://chatgpt.com/codex/tasks/task_e_6853ea06a488832e95ffcf21cb902e38