### PR TITLE
Use English search terms for encyclopedia photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ the API routes, while React components rely on **React Testing Library**.
 - `src/contexts` – global `ContentProvider` that loads week data and tracks progress
 - `src/modules` – individual learning modules (Language, Math, Encyclopedia)
 - `src/screens` – page components for the router
-- `public/weeks` – JSON data files per week
+- `public/weeks` – JSON data files per week. Encyclopedia cards include a
+  `query` field with an English search term used for fetching photos
 - `src/utils/fetchWeek.js` – helper to fetch a week's JSON by number
 - `src/utils/fetchPhoto.js` – fetches an Unsplash image for a given query
  - Language words now display in a very large lowercase font so toddlers

--- a/public/weeks/week001.json
+++ b/public/weeks/week001.json
@@ -13,15 +13,15 @@
   ],
   "mathWindowStart": 1,
   "encyclopedia": [
-    { "id": "afghaanse-hond", "title": "Afgaanse hond", "fact": "This hound has long, silky hair.", "image": "/images/dog.svg" },
-    { "id": "goudkleurige-apporteerhond", "title": "Goudkleurige Apporteerhond", "fact": "This retriever loves to fetch.", "image": "/images/dog.svg" },
-    { "id": "dalmatiese-hond", "title": "Dalmatiese hond", "fact": "Known for its white coat with black spots.", "image": "/images/dog.svg" },
-    { "id": "dashond", "title": "Dashond", "fact": "This breed has a long body and short legs.", "image": "/images/dog.svg" },
-    { "id": "franse-dashond", "title": "Franse Dashond", "fact": "A playful companion from France.", "image": "/images/dog.svg" },
-    { "id": "jagwindhond", "title": "Jagwindhond", "fact": "This sighthound can run very fast.", "image": "/images/dog.svg" },
-    { "id": "bulhond", "title": "Bulhond", "fact": "Bulldogs have a distinctive wrinkled face.", "image": "/images/dog.svg" },
-    { "id": "engelse-patryshond", "title": "Engelse Patryshond", "fact": "English Pointers excel at bird hunting.", "image": "/images/dog.svg" },
-    { "id": "bloedhond", "title": "Bloedhond", "fact": "Bloodhounds have an exceptional sense of smell.", "image": "/images/dog.svg" },
-    { "id": "rhodesiese-rifrughond", "title": "Rhodesiese Rifrughond", "fact": "This dog has a ridge of hair along its back.", "image": "/images/dog.svg" }
+    { "id": "afghaanse-hond", "title": "Afgaanse hond", "query": "Afghan hound", "fact": "This hound has long, silky hair.", "image": "/images/dog.svg" },
+    { "id": "goudkleurige-apporteerhond", "title": "Goudkleurige Apporteerhond", "query": "Golden Retriever", "fact": "This retriever loves to fetch.", "image": "/images/dog.svg" },
+    { "id": "dalmatiese-hond", "title": "Dalmatiese hond", "query": "Dalmatian", "fact": "Known for its white coat with black spots.", "image": "/images/dog.svg" },
+    { "id": "dashond", "title": "Dashond", "query": "Dachshund", "fact": "This breed has a long body and short legs.", "image": "/images/dog.svg" },
+    { "id": "franse-dashond", "title": "Franse Dashond", "query": "Basset Hound", "fact": "A playful companion from France.", "image": "/images/dog.svg" },
+    { "id": "jagwindhond", "title": "Jagwindhond", "query": "greyhound", "fact": "This sighthound can run very fast.", "image": "/images/dog.svg" },
+    { "id": "bulhond", "title": "Bulhond", "query": "Bulldog", "fact": "Bulldogs have a distinctive wrinkled face.", "image": "/images/dog.svg" },
+    { "id": "engelse-patryshond", "title": "Engelse Patryshond", "query": "English pointer", "fact": "English Pointers excel at bird hunting.", "image": "/images/dog.svg" },
+    { "id": "bloedhond", "title": "Bloedhond", "query": "Bloodhound", "fact": "Bloodhounds have an exceptional sense of smell.", "image": "/images/dog.svg" },
+    { "id": "rhodesiese-rifrughond", "title": "Rhodesiese Rifrughond", "query": "Rhodesian Ridgeback", "fact": "This dog has a ridge of hair along its back.", "image": "/images/dog.svg" }
   ]
 }

--- a/public/weeks/week002.json
+++ b/public/weeks/week002.json
@@ -13,15 +13,15 @@
   ],
   "mathWindowStart": 6,
   "encyclopedia": [
-    {"id": "rob-bruin-himalajan-kat", "title": "Rob bruin Himalajan kat", "fact": "Known for its rounded brown coat.", "image": "/images/cat.svg"},
-    {"id": "siamese-kat", "title": "Siamese kat", "fact": "Recognizable by its point coloration.", "image": "/images/cat.svg"},
-    {"id": "turkse-van-kat", "title": "Turkse Van kat", "fact": "Loves swimming and has a white body.", "image": "/images/cat.svg"},
-    {"id": "chinchilla-kat", "title": "Chinchilla kat", "fact": "Has a soft, silvery coat.", "image": "/images/cat.svg"},
-    {"id": "rooi-persiese-kat", "title": "Rooi Persiese kat", "fact": "A Persian breed with red fur.", "image": "/images/cat.svg"},
-    {"id": "rokerige-swart-persiese-kat", "title": "Rokerige Swart Persiese kat", "fact": "Features a smoky black coat.", "image": "/images/cat.svg"},
-    {"id": "turkse-angora-kat", "title": "Turkse Angora kat", "fact": "Elegant cat with a silky tail.", "image": "/images/cat.svg"},
-    {"id": "abbesinier-kat", "title": "Abbesini\u00e9r kat", "fact": "Agile breed with ticked fur.", "image": "/images/cat.svg"},
-    {"id": "maine-coon", "title": "Maine Coon", "fact": "Large breed known for its tufted ears.", "image": "/images/cat.svg"},
-    {"id": "ragdoll-kat", "title": "Ragdoll kat", "fact": "Called ragdoll for its relaxed pose.", "image": "/images/cat.svg"}
+    {"id": "rob-bruin-himalajan-kat", "title": "Rob bruin Himalajan kat", "query": "Himalayan cat", "fact": "Known for its rounded brown coat.", "image": "/images/cat.svg"},
+    {"id": "siamese-kat", "title": "Siamese kat", "query": "Siamese cat", "fact": "Recognizable by its point coloration.", "image": "/images/cat.svg"},
+    {"id": "turkse-van-kat", "title": "Turkse Van kat", "query": "Turkish Van cat", "fact": "Loves swimming and has a white body.", "image": "/images/cat.svg"},
+    {"id": "chinchilla-kat", "title": "Chinchilla kat", "query": "Chinchilla cat", "fact": "Has a soft, silvery coat.", "image": "/images/cat.svg"},
+    {"id": "rooi-persiese-kat", "title": "Rooi Persiese kat", "query": "Red Persian cat", "fact": "A Persian breed with red fur.", "image": "/images/cat.svg"},
+    {"id": "rokerige-swart-persiese-kat", "title": "Rokerige Swart Persiese kat", "query": "Smoky black Persian cat", "fact": "Features a smoky black coat.", "image": "/images/cat.svg"},
+    {"id": "turkse-angora-kat", "title": "Turkse Angora kat", "query": "Turkish Angora cat", "fact": "Elegant cat with a silky tail.", "image": "/images/cat.svg"},
+    {"id": "abbesinier-kat", "title": "Abbesini\u00e9r kat", "query": "Abyssinian cat", "fact": "Agile breed with ticked fur.", "image": "/images/cat.svg"},
+    {"id": "maine-coon", "title": "Maine Coon", "query": "Maine Coon", "fact": "Large breed known for its tufted ears.", "image": "/images/cat.svg"},
+    {"id": "ragdoll-kat", "title": "Ragdoll kat", "query": "Ragdoll cat", "fact": "Called ragdoll for its relaxed pose.", "image": "/images/cat.svg"}
   ]
 }

--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -13,7 +13,8 @@ const EncyclopediaModule = ({ cards }) => {
 
     let active = true
     shuffled.forEach((card, index) => {
-      fetchPhoto(card.title)
+      const searchTerm = card.query || card.title
+      fetchPhoto(searchTerm)
         .then((url) => {
           if (active) {
             setItems((prev) => {

--- a/src/modules/EncyclopediaModule.test.jsx
+++ b/src/modules/EncyclopediaModule.test.jsx
@@ -42,4 +42,29 @@ describe('EncyclopediaModule', () => {
       expect(img).toHaveAttribute('src', 'https://img.test/photo.jpg'),
     )
   })
+
+  it('uses the query field when provided', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://img.test/photo2.jpg' }),
+    })
+    global.fetch = fetchMock
+    globalThis.fetch = fetchMock
+    if (typeof window !== 'undefined') {
+      window.fetch = fetchMock
+    }
+
+    const cards = [
+      { image: '/images/test.svg', title: 'Leeu', query: 'Lion', fact: 'King' },
+    ]
+    render(<EncyclopediaModule cards={cards} />)
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith('/api/photos?query=Lion'),
+    )
+    const img = screen.getByRole('img', { name: 'Leeu' })
+    await waitFor(() =>
+      expect(img).toHaveAttribute('src', 'https://img.test/photo2.jpg'),
+    )
+  })
 });


### PR DESCRIPTION
## Summary
- map encyclopedia queries to English search terms on the frontend
- add `query` field to week data for photo lookups
- document the new `query` field in the README
- test that `query` is used when fetching photos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ed4ac90c832e801fdffb47f6cbd0