### PR TITLE
Implement responsive photo formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,16 +149,15 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 ### Photo Search API
 
-`GET /api/photos?query=term` searches Unsplash and returns the first image URL.
-The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans
-dog breed names are translated to their English equivalents so Unsplash can find
-matching photos. A failed Unsplash request responds with `{ "detail": "Unsplash request failed", "error": "message" }`,
-where the `error` field contains either the Unsplash response text or the network
-error message.
-If the request fails on the client, the app falls back to `/images/placeholder.png`. The file is not included in the repo; add your own placeholder image at `public/images/placeholder.png`.
-
+`GET /api/photos?query=term` searches Unsplash and returns URLs for multiple image sizes.
+Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }`.
+Include a `format` query (`small` or `regular`) to receive a single `{ "url": "..." }` instead.
+The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.
+A failed Unsplash request responds with `{ "detail": "Unsplash request failed", "error": "message" }`,
+where the `error` field contains either the Unsplash response text or the network error message.
+If the request fails on the client, the app falls back to `/images/placeholder.png`.
+The file is not included in the repo; add your own placeholder image at `public/images/placeholder.png`.
 ### Interpreting Server Logs
-
 The server uses the `morgan` middleware in the `combined` format to log every
 incoming HTTP request. Each line shows the method, URL, response status and
 response time. In addition, the generic error handler prints any unexpected

--- a/server.js
+++ b/server.js
@@ -100,7 +100,7 @@ app.post('/api/register', async (req, res) => {
 });
 
 app.get('/api/photos', async (req, res) => {
-  const { query } = req.query;
+  const { query, format } = req.query;
   if (!query) {
     res.status(400).json({ detail: 'Missing query parameter' });
     return;
@@ -127,7 +127,13 @@ app.get('/api/photos', async (req, res) => {
       res.status(404).json({ detail: 'Unsplash request failed' });
       return;
     }
-    res.json({ url: data.results[0].urls.small });
+
+    const { urls } = data.results[0];
+    if (format && urls[format]) {
+      res.json({ url: urls[format] });
+    } else {
+      res.json({ small: urls.small, regular: urls.regular });
+    }
   } catch (err) {
     console.error('Fetch to Unsplash failed', err);
     res.status(502).json({ detail: 'Unsplash request failed', error: err.message });

--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -15,11 +15,11 @@ const EncyclopediaModule = ({ cards }) => {
     shuffled.forEach((card, index) => {
       const searchTerm = card.query || card.title
       fetchPhoto(searchTerm)
-        .then((url) => {
+        .then((img) => {
           if (active) {
             setItems((prev) => {
               const next = [...prev]
-              next[index] = { ...next[index], image: url }
+              next[index] = { ...next[index], image: img }
               return next
             })
           }
@@ -37,18 +37,29 @@ const EncyclopediaModule = ({ cards }) => {
   return (
     <Carousel
       items={items}
-      renderItem={(card) => (
-        <div className="space-y-2">
-          <img
-            loading="lazy"
-            src={card.image}
-            alt={card.title}
-            className="w-full h-48 sm:h-64 object-cover rounded-xl"
-          />
-          <h3 className="text-xl font-bold">{card.title}</h3>
-          <p className="text-gray-600">{card.fact}</p>
-        </div>
-      )}
+      renderItem={(card) => {
+        const img =
+          typeof card.image === 'string'
+            ? { avif: card.image, webp: card.image, fallback: card.image }
+            : card.image
+
+        return (
+          <div className="space-y-2">
+            <picture>
+              <source type="image/avif" srcSet={img.avif} />
+              <source type="image/webp" srcSet={img.webp} />
+              <img
+                loading="lazy"
+                src={img.fallback}
+                alt={card.title}
+                className="w-full h-48 sm:h-64 object-cover rounded-xl"
+              />
+            </picture>
+            <h3 className="text-xl font-bold">{card.title}</h3>
+            <p className="text-gray-600">{card.fact}</p>
+          </div>
+        )
+      }}
     />
   )
 }

--- a/src/modules/EncyclopediaModule.test.jsx
+++ b/src/modules/EncyclopediaModule.test.jsx
@@ -16,12 +16,18 @@ describe('EncyclopediaModule', () => {
     const img = screen.getByRole('img', { name: 'Test Card' });
     expect(img).toHaveAttribute('alt', 'Test Card');
     expect(img).toHaveClass('w-full', 'h-48', 'sm:h-64', 'object-cover', 'rounded-xl');
+    const picture = img.closest('picture');
+    expect(picture).not.toBeNull();
+    const sources = picture.querySelectorAll('source');
+    expect(sources).toHaveLength(2);
+    expect(sources[0]).toHaveAttribute('type', 'image/avif');
+    expect(sources[1]).toHaveAttribute('type', 'image/webp');
   });
 
   it('fetches remote photos and replaces defaults', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ url: 'https://img.test/photo.jpg' }),
+      json: async () => ({ small: 'https://img.test/s.jpg', regular: 'https://img.test/r.jpg' }),
     })
     global.fetch = fetchMock
     globalThis.fetch = fetchMock
@@ -39,14 +45,14 @@ describe('EncyclopediaModule', () => {
     )
     const img = screen.getByRole('img', { name: 'Lion' })
     await waitFor(() =>
-      expect(img).toHaveAttribute('src', 'https://img.test/photo.jpg'),
+      expect(img).toHaveAttribute('src', 'https://img.test/s.jpg'),
     )
   })
 
   it('uses the query field when provided', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ url: 'https://img.test/photo2.jpg' }),
+      json: async () => ({ small: 'https://img.test/s2.jpg', regular: 'https://img.test/r2.jpg' }),
     })
     global.fetch = fetchMock
     globalThis.fetch = fetchMock
@@ -64,7 +70,7 @@ describe('EncyclopediaModule', () => {
     )
     const img = screen.getByRole('img', { name: 'Leeu' })
     await waitFor(() =>
-      expect(img).toHaveAttribute('src', 'https://img.test/photo2.jpg'),
+      expect(img).toHaveAttribute('src', 'https://img.test/s2.jpg'),
     )
   })
 });

--- a/src/utils/fetchPhoto.js
+++ b/src/utils/fetchPhoto.js
@@ -16,13 +16,36 @@ export async function fetchPhoto(query) {
     console.log('Unsplash body', body);
 
     if (!res.ok) {
-      return '/images/placeholder.png';
+      return {
+        avif: '/images/placeholder.png',
+        webp: '/images/placeholder.png',
+        fallback: '/images/placeholder.png',
+      };
     }
 
     const data = JSON.parse(body);
-    return data.url || '/images/placeholder.png';
+    const regular = data.regular || data.url;
+    const small = data.small || regular;
+
+    if (!regular) {
+      return {
+        avif: '/images/placeholder.png',
+        webp: '/images/placeholder.png',
+        fallback: '/images/placeholder.png',
+      };
+    }
+
+    return {
+      avif: `${regular}&fm=avif`,
+      webp: `${regular}&fm=webp`,
+      fallback: small,
+    };
   } catch (err) {
     console.error('Photo fetch failed', err);
-    return '/images/placeholder.png';
+    return {
+      avif: '/images/placeholder.png',
+      webp: '/images/placeholder.png',
+      fallback: '/images/placeholder.png',
+    };
   }
 }

--- a/tests/fetchPhoto.test.js
+++ b/tests/fetchPhoto.test.js
@@ -19,15 +19,19 @@ describe('fetchPhoto', () => {
     delete global.fetch
   })
 
-  test('returns URL on success', async () => {
-    const url = 'http://img.test/photo.jpg'
+  test('returns URLs on success', async () => {
+    const data = { small: 'http://img.test/small.jpg', regular: 'http://img.test/reg.jpg' }
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ url }),
+      text: async () => JSON.stringify(data),
     })
 
-    await expect(fetchPhoto('cats')).resolves.toBe(url)
+    await expect(fetchPhoto('cats')).resolves.toEqual({
+      avif: `${data.regular}&fm=avif`,
+      webp: `${data.regular}&fm=webp`,
+      fallback: data.small,
+    })
   })
 
   test('returns placeholder on 404', async () => {
@@ -37,13 +41,21 @@ describe('fetchPhoto', () => {
       text: async () => 'Not found',
     })
 
-    await expect(fetchPhoto('cats')).resolves.toBe('/images/placeholder.png')
+    await expect(fetchPhoto('cats')).resolves.toEqual({
+      avif: '/images/placeholder.png',
+      webp: '/images/placeholder.png',
+      fallback: '/images/placeholder.png',
+    })
   })
 
   test('returns placeholder on network error', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('fail'))
 
-    await expect(fetchPhoto('cats')).resolves.toBe('/images/placeholder.png')
+    await expect(fetchPhoto('cats')).resolves.toEqual({
+      avif: '/images/placeholder.png',
+      webp: '/images/placeholder.png',
+      fallback: '/images/placeholder.png',
+    })
     expect(errorSpy).toHaveBeenCalledWith('Photo fetch failed', expect.any(Error))
   })
 })


### PR DESCRIPTION
## Summary
- return multiple photo URLs from `/api/photos`
- generate AVIF, WebP and fallback URLs in `fetchPhoto`
- render `<picture>` tag in Encyclopedia module
- update README for API changes
- adjust related tests for new photo structure

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f3349394832eaad5a37cbb26455f