### PR TITLE
Apply responsive aspect ratio to encyclopedia images

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ exceeding `max-w-xs`.
 The progress table now uses `table-fixed` so its seven columns fit within a
 360&nbsp;px wide viewport, and the action buttons are arranged in a single-column
 grid that expands to four columns on larger screens.
-Encyclopedia images now use `h-48 sm:h-64` so photos scale down on mobile devices.
+Encyclopedia images now use an `.encyclopedia-thumb` class with
+`aspect-ratio: 3 / 2` so photos scale consistently on mobile devices.
 
 Full-screen areas leverage viewport units so layouts adapt to device height.
 The math board scales with the viewport width while carousels always take up at

--- a/src/index.css
+++ b/src/index.css
@@ -100,4 +100,10 @@
     padding: 0.25rem;
     border: 1px solid rgb(209 213 219); /* tailwind gray-300 */
   }
+
+  /* Keep encyclopedia images consistent regardless of width */
+  .encyclopedia-thumb {
+    aspect-ratio: 3 / 2;
+    object-fit: cover;
+  }
 }

--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -52,7 +52,7 @@ const EncyclopediaModule = ({ cards }) => {
                 loading="lazy"
                 src={img.fallback}
                 alt={card.title}
-                className="w-full h-48 sm:h-64 object-cover rounded-xl"
+                className="w-full rounded-xl encyclopedia-thumb"
               />
             </picture>
             <h3 className="text-xl font-bold">{card.title}</h3>

--- a/src/modules/EncyclopediaModule.test.jsx
+++ b/src/modules/EncyclopediaModule.test.jsx
@@ -15,7 +15,7 @@ describe('EncyclopediaModule', () => {
     render(<EncyclopediaModule cards={cards} />);
     const img = screen.getByRole('img', { name: 'Test Card' });
     expect(img).toHaveAttribute('alt', 'Test Card');
-    expect(img).toHaveClass('w-full', 'h-48', 'sm:h-64', 'object-cover', 'rounded-xl');
+    expect(img).toHaveClass('w-full', 'rounded-xl', 'encyclopedia-thumb');
     const picture = img.closest('picture');
     expect(picture).not.toBeNull();
     const sources = picture.querySelectorAll('source');


### PR DESCRIPTION
## Summary
- add `.encyclopedia-thumb` CSS helper
- use new helper in `EncyclopediaModule`
- update unit tests for new class
- document aspect ratio requirement in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853f4d4c3cc832eb786e599ed9457c1