### PR TITLE
Add zoom image styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ The progress table now uses `table-fixed` so its seven columns fit within a
 360&nbsp;px wide viewport, and the action buttons are arranged in a single-column
 grid that expands to four columns on larger screens.
 Encyclopedia images now use an `.encyclopedia-thumb` class with
-`aspect-ratio: 3 / 2` so photos scale consistently on mobile devices.
+`aspect-ratio: 3 / 2` so photos scale consistently on mobile devices. A
+`zoom-img` class adds a gentle scale animation on hover starting at the `md`
+breakpoint, leaving touch devices unaffected.
 
 Full-screen areas leverage viewport units so layouts adapt to device height.
 The math board scales with the viewport width while carousels always take up at

--- a/src/index.css
+++ b/src/index.css
@@ -106,4 +106,13 @@
     aspect-ratio: 3 / 2;
     object-fit: cover;
   }
+
+  .zoom-img {
+    transition: transform 0.2s;
+  }
+  @media (min-width: 768px) {
+    .zoom-img:hover {
+      transform: scale(1.05);
+    }
+  }
 }

--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -45,7 +45,7 @@ const EncyclopediaModule = ({ cards }) => {
 
         return (
           <div className="space-y-2">
-            <picture>
+            <picture className="zoom-img">
               <source type="image/avif" srcSet={img.avif} />
               <source type="image/webp" srcSet={img.webp} />
               <img

--- a/src/modules/EncyclopediaModule.test.jsx
+++ b/src/modules/EncyclopediaModule.test.jsx
@@ -18,6 +18,7 @@ describe('EncyclopediaModule', () => {
     expect(img).toHaveClass('w-full', 'rounded-xl', 'encyclopedia-thumb');
     const picture = img.closest('picture');
     expect(picture).not.toBeNull();
+    expect(picture).toHaveClass('zoom-img');
     const sources = picture.querySelectorAll('source');
     expect(sources).toHaveLength(2);
     expect(sources[0]).toHaveAttribute('type', 'image/avif');
@@ -27,7 +28,10 @@ describe('EncyclopediaModule', () => {
   it('fetches remote photos and replaces defaults', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ small: 'https://img.test/s.jpg', regular: 'https://img.test/r.jpg' }),
+      text: async () => JSON.stringify({
+        small: 'https://img.test/s.jpg',
+        regular: 'https://img.test/r.jpg',
+      }),
     })
     global.fetch = fetchMock
     globalThis.fetch = fetchMock
@@ -52,7 +56,10 @@ describe('EncyclopediaModule', () => {
   it('uses the query field when provided', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ small: 'https://img.test/s2.jpg', regular: 'https://img.test/r2.jpg' }),
+      text: async () => JSON.stringify({
+        small: 'https://img.test/s2.jpg',
+        regular: 'https://img.test/r2.jpg',
+      }),
     })
     global.fetch = fetchMock
     globalThis.fetch = fetchMock


### PR DESCRIPTION
## Summary
- allow images to zoom on desktop
- apply zoom styling to encyclopedia pictures
- verify zoom class in tests
- document hover animation in README

## Testing
- `npm run lint`
- `npx jest src/modules/EncyclopediaModule.test.jsx`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f58f9fd0832e8a88c0b0e38b905d