### PR TITLE
Update Unsplash request parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 ### Photo Search API
 
 `GET /api/photos?query=term` searches Unsplash and returns URLs for multiple image sizes.
+The server requests photos with `w=640&q=80` so images are compressed and smaller on the wire.
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }`.
 Include a `format` query (`small` or `regular`) to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.
-A failed Unsplash request responds with `{ "detail": "Unsplash request failed", "error": "message" }`,
-where the `error` field contains either the Unsplash response text or the network error message.
+A failed Unsplash request responds with `{ "detail": "Unsplash request failed", "status": <code>, "error": "message" }`,
+where `status` and `error` come directly from Unsplash when available.
 If the request fails on the client, the app falls back to `/images/placeholder.png`.
 The file is not included in the repo; add your own placeholder image at `public/images/placeholder.png`.
 ### Interpreting Server Logs

--- a/server.js
+++ b/server.js
@@ -108,7 +108,9 @@ app.get('/api/photos', async (req, res) => {
   res.set('Cache-Control', 'no-store');
   try {
     const searchTerm = breedMap[query] || query;
-    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(searchTerm)}&per_page=1`;
+    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(
+      searchTerm,
+    )}&per_page=1&w=640&q=80`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Client-ID ${process.env.UNSPLASH_ACCESS_KEY}`,
@@ -116,10 +118,12 @@ app.get('/api/photos', async (req, res) => {
     });
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('Unsplash error', errorText);
-      res
-        .status(response.status)
-        .json({ detail: 'Unsplash request failed', error: errorText });
+      console.error('Unsplash error', response.status, errorText);
+      res.status(response.status).json({
+        detail: 'Unsplash request failed',
+        status: response.status,
+        error: errorText,
+      });
       return;
     }
     const data = await response.json();

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -134,6 +134,25 @@ describe('photo endpoint', () => {
     expect(res.body.url).toBe('http://img.test/r.jpg');
   });
 
+  test('requests compressed photo', async () => {
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ urls: { small: 's', regular: 'r' } }],
+      }),
+    });
+
+    const res = await request(app)
+      .get('/api/photos')
+      .query({ query: 'cats' });
+
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('&w=640&q=80'),
+      expect.any(Object),
+    );
+  });
+
   test('handles failed Unsplash response', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary
- compress Unsplash photos with `w=640&q=80`
- log response status and body from Unsplash when the request fails
- test that the extra parameters are sent
- document photo API optimizations

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853f684d800832eb2348a4708504b4b