### PR TITLE
Update Unsplash fetch and add helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,12 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 ### Photo Search API
 
-`GET /api/photos?query=term` searches Unsplash and returns URLs for multiple image sizes.
-The server requests photos with `w=640&q=80` so images are compressed and smaller on the wire.
-Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }`.
-Include a `format` query (`small` or `regular`) to receive a single `{ "url": "..." }` instead.
+`GET /api/photos?query=term` searches Unsplash and returns a compressed landscape photo.
+The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed.
+Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
+Include a `format` query to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.
-A failed Unsplash request responds with `{ "detail": "Unsplash request failed", "status": <code>, "error": "message" }`,
-where `status` and `error` come directly from Unsplash when available.
+A failed Unsplash lookup results in a `404` response with `{ "detail": "Unsplash request failed" }`.
 If the request fails on the client, the app falls back to `/images/placeholder.png`.
 The file is not included in the repo; add your own placeholder image at `public/images/placeholder.png`.
 ### Interpreting Server Logs

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -1,0 +1,43 @@
+let fetchCleanPhoto
+
+beforeAll(async () => {
+  ;({ default: fetchCleanPhoto } = await import('../utils/fetchCleanPhoto.js'))
+})
+
+describe('fetchCleanPhoto', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete global.fetch
+  })
+
+  test('returns first result', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ urls: { small: 'http://img.test/a.jpg' } }] }),
+    })
+
+    await expect(fetchCleanPhoto('cats')).resolves.toBe('http://img.test/a.jpg')
+  })
+
+  test('falls back through queries', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'Not found' })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [{ urls: { small: 'dog.jpg' } }] }) })
+
+    const result = await fetchCleanPhoto('pug')
+    expect(result).toBe('dog.jpg')
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(global.fetch.mock.calls[0][0]).toContain('isolated')
+    expect(global.fetch.mock.calls[2][0]).toContain('dog%20white%20background')
+  })
+
+  test('returns placeholder on failure', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404, text: async () => 'Not found' })
+
+    const result = await fetchCleanPhoto('pug')
+    expect(result).toBe('/images/placeholder.png')
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -65,7 +65,7 @@ describe('photo endpoint', () => {
       ok: true,
       json: async () => ({
         results: [
-          { urls: { small: 'http://img.test/photo-small.jpg', regular: 'http://img.test/photo-reg.jpg' } },
+          { urls: { small: 'http://img.test/photo-small.jpg' } },
         ],
       }),
     });
@@ -77,7 +77,7 @@ describe('photo endpoint', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       small: 'http://img.test/photo-small.jpg',
-      regular: 'http://img.test/photo-reg.jpg',
+      regular: 'http://img.test/photo-small.jpg',
     });
     expect(global.fetch).toHaveBeenCalled();
   });
@@ -96,7 +96,7 @@ describe('photo endpoint', () => {
         ok: true,
         json: async () => ({
           results: [
-            { urls: { small: `http://img.test/${english}.jpg`, regular: `http://img.test/${english}-reg.jpg` } },
+            { urls: { small: `http://img.test/${english}.jpg` } },
           ],
         }),
       });
@@ -107,7 +107,7 @@ describe('photo endpoint', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.small).toBe(`http://img.test/${english}.jpg`);
-      expect(res.body.regular).toBe(`http://img.test/${english}-reg.jpg`);
+      expect(res.body.regular).toBe(`http://img.test/${english}.jpg`);
       const encoded = encodeURIComponent(english);
       expect(spy).toHaveBeenCalledWith(
         expect.stringContaining(encoded),
@@ -121,7 +121,7 @@ describe('photo endpoint', () => {
       ok: true,
       json: async () => ({
         results: [
-          { urls: { small: 'http://img.test/s.jpg', regular: 'http://img.test/r.jpg' } },
+          { urls: { small: 'http://img.test/s.jpg' } },
         ],
       }),
     });
@@ -131,14 +131,14 @@ describe('photo endpoint', () => {
       .query({ query: 'cats', format: 'regular' });
 
     expect(res.status).toBe(200);
-    expect(res.body.url).toBe('http://img.test/r.jpg');
+    expect(res.body.url).toBe('http://img.test/s.jpg');
   });
 
   test('requests compressed photo', async () => {
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({
-        results: [{ urls: { small: 's', regular: 'r' } }],
+        results: [{ urls: { small: 's' } }],
       }),
     });
 
@@ -148,7 +148,7 @@ describe('photo endpoint', () => {
 
     expect(res.status).toBe(200);
     expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('&w=640&q=80'),
+      expect.stringContaining('orientation=landscape'),
       expect.any(Object),
     );
   });
@@ -164,8 +164,7 @@ describe('photo endpoint', () => {
       .get('/api/photos')
       .query({ query: 'dogs' });
 
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(404);
     expect(res.body.detail).toBe('Unsplash request failed');
-    expect(res.body.error).toBe('Error');
   });
 });

--- a/utils/fetchCleanPhoto.js
+++ b/utils/fetchCleanPhoto.js
@@ -1,0 +1,34 @@
+import { breedMap } from '../server.js'
+
+const UNSPLASH_URL = 'https://api.unsplash.com/search/photos'
+
+export default async function fetchCleanPhoto(rawQuery) {
+  const term = breedMap[rawQuery] || rawQuery
+  const queries = [
+    `${term} isolated minimal background`,
+    `${term} white background`,
+    'dog white background',
+  ]
+
+  for (const q of queries) {
+    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(q)}&color=white&orientation=landscape&per_page=3`
+    try {
+      const res = await fetch(url, {
+        headers: { Authorization: `Client-ID ${process.env.UNSPLASH_ACCESS_KEY}` },
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        console.error('Unsplash error', res.status, text)
+        if (res.status === 404) continue
+        continue
+      }
+      const data = await res.json()
+      if (data.results && data.results[0] && data.results[0].urls && data.results[0].urls.small) {
+        return data.results[0].urls.small
+      }
+    } catch (err) {
+      console.error('Fetch failed', err)
+    }
+  }
+  return '/images/placeholder.png'
+}


### PR DESCRIPTION
## Summary
- create `utils/fetchCleanPhoto` helper for multi-term Unsplash searches
- update `/api/photos` endpoint to use the helper and return placeholder on failure
- document updated behaviour in README
- add unit tests for `fetchCleanPhoto`
- adjust server tests for new API behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853fa1f2a08832e92e2a3c7e623571c