### PR TITLE
Improve Unsplash photo cropping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 .env
+users.db

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 ### Photo Search API
 
-`GET /api/photos?query=term` searches Unsplash and returns a compressed landscape photo.
-The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed.
+`GET /api/photos?query=term` searches Unsplash and returns a 640×360 smart-cropped landscape photo.
+The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed. Unsplash uses Imgix to crop the image to center faces or the most interesting region.
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
 Include a `format` query to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -19,6 +19,18 @@ describe('fetchCleanPhoto', () => {
     await expect(fetchCleanPhoto('cats')).resolves.toBe('http://img.test/a.jpg')
   })
 
+  test('includes smart crop parameters', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ urls: { small: 'http://img.test/a.jpg' } }] }),
+    })
+
+    await fetchCleanPhoto('pug')
+    const callUrl = global.fetch.mock.calls[0][0]
+    expect(callUrl).toContain('fit=crop')
+    expect(callUrl).toContain('crop=faces,entropy')
+  })
+
   test('falls back through queries', async () => {
     global.fetch = jest
       .fn()

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -147,10 +147,13 @@ describe('photo endpoint', () => {
       .query({ query: 'cats' });
 
     expect(res.status).toBe(200);
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('orientation=landscape'),
-      expect.any(Object),
-    );
+    const callUrl = spy.mock.calls[0][0]
+    expect(callUrl).toContain('orientation=landscape')
+    expect(callUrl).toContain('per_page=1')
+    expect(callUrl).toContain('w=640')
+    expect(callUrl).toContain('h=360')
+    expect(callUrl).toContain('fit=crop')
+    expect(callUrl).toContain('crop=faces,entropy')
   });
 
   test('handles failed Unsplash response', async () => {

--- a/utils/fetchCleanPhoto.js
+++ b/utils/fetchCleanPhoto.js
@@ -11,14 +11,14 @@ export default async function fetchCleanPhoto(rawQuery) {
   ]
 
   for (const q of queries) {
-    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(q)}&color=white&orientation=landscape&per_page=3`
+    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(q)}&color=white&orientation=landscape&per_page=1&w=640&h=360&fit=crop&crop=faces,entropy`
     try {
       const res = await fetch(url, {
         headers: { Authorization: `Client-ID ${process.env.UNSPLASH_ACCESS_KEY}` },
       })
       if (!res.ok) {
         const text = await res.text().catch(() => '')
-        console.error('Unsplash error', res.status, text)
+        console.error(`Unsplash error for "${q}"`, res.status, text)
         if (res.status === 404) continue
         continue
       }


### PR DESCRIPTION
## Summary
- crop Unsplash images to 640x360 focusing on faces or interesting regions
- log fetch errors with the query included
- test for smart-crop parameters
- document new photo search behaviour
- ignore local users.db database

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853fd33cf7c832e99f4f2ca960526ee