### PR TITLE
Handle query strings when cropping Unsplash URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 `GET /api/photos?query=term` searches Unsplash and returns a 640×360 smart-cropped landscape photo.
 The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed.
-It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash URL so Imgix crops around faces or the most interesting region.
+It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash URL so Imgix crops around faces or the most interesting region. If the original Unsplash link already includes query parameters, the cropping string is concatenated with `&` instead of `?`.
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
 Include a `format` query to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -21,6 +21,17 @@ describe('fetchCleanPhoto', () => {
     )
   })
 
+  test('handles existing query strings', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg?foo=1' } }] }),
+    })
+
+    await expect(fetchCleanPhoto('cats')).resolves.toBe(
+      'http://img.test/a.jpg?foo=1&w=640&h=360&fit=crop&crop=faces,entropy',
+    )
+  })
+
   test('includes smart crop parameters', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -83,6 +83,26 @@ describe('photo endpoint', () => {
     expect(global.fetch).toHaveBeenCalled();
   });
 
+  test('adds crop params with ampersand when query exists', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          { urls: { raw: 'http://img.test/photo-small.jpg?foo=1' } },
+        ],
+      }),
+    });
+
+    const res = await request(app)
+      .get('/api/photos')
+      .query({ query: 'cats' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.small).toBe(
+      'http://img.test/photo-small.jpg?foo=1&w=640&h=360&fit=crop&crop=faces,entropy',
+    );
+  });
+
   const translations = [
     ['Jagwindhond', 'greyhound'],
     ['Dashond', 'Dachshund'],

--- a/utils/fetchCleanPhoto.js
+++ b/utils/fetchCleanPhoto.js
@@ -27,7 +27,9 @@ export default async function fetchCleanPhoto(rawQuery) {
       if (data.results && data.results[0] && data.results[0].urls) {
         const { raw, regular } = data.results[0].urls;
         if (raw || regular) {
-          return `${raw || regular}?${CROP_PARAMS}`;
+          const baseUrl = raw || regular;
+          const join = baseUrl.includes('?') ? '&' : '?';
+          return `${baseUrl}${join}${CROP_PARAMS}`;
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- fix `fetchCleanPhoto` to append crop params using `?` or `&`
- test cropping with existing query strings
- document how crop params are appended

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854051f802c832eac7282b4e85696db