### PR TITLE
Refactor auth helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Create these keys by signing up for a developer account at [Unsplash](https://un
 The default credentials are **demo@example.com** / **password**. You can also
 register a new account using the **Sign Up** page. Successful authentication
 returns a token stored in `localStorage` by the `AuthProvider`.
+Access this context via the `useAuth` hook exported from
+`src/contexts/authHelpers.js`.
 
 During development the API server runs on `http://localhost:3001`, so the
 `VITE_API_BASE_URL` variable should point there. For production builds set it to

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,6 +1,6 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import SettingsButton from './SettingsButton';
-import { useAuth } from '../contexts/AuthProvider';
+import { useAuth } from '../contexts/authHelpers';
 
 const NavBar = () => {
   const navigate = useNavigate();

--- a/src/contexts/AuthProvider.jsx
+++ b/src/contexts/AuthProvider.jsx
@@ -1,20 +1,10 @@
-import React, { createContext, useContext, useState } from 'react';
-
-const AuthContext = createContext();
-
-export function useAuth() {
-  return useContext(AuthContext);
-}
-
-const AUTH_KEY = 'auth-token';
+import React, { useState } from 'react';
+import { AuthContext, AUTH_KEY, getBaseUrl } from './authHelpers';
 
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem(AUTH_KEY));
 
-  const baseUrl =
-    (import.meta.env && import.meta.env.VITE_API_BASE_URL) ||
-    process.env.VITE_API_BASE_URL ||
-    '';
+  const baseUrl = getBaseUrl();
 
   const login = async (email, password) => {
     const res = await fetch(`${baseUrl}/api/login`, {
@@ -59,3 +49,4 @@ export const AuthProvider = ({ children }) => {
     </AuthContext.Provider>
   );
 };
+

--- a/src/contexts/AuthProvider.test.jsx
+++ b/src/contexts/AuthProvider.test.jsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
-import { AuthProvider, useAuth } from './AuthProvider';
+import { AuthProvider } from './AuthProvider';
+import { useAuth } from './authHelpers';
 
 const Caller = ({ action }) => {
   const auth = useAuth();

--- a/src/contexts/authHelpers.js
+++ b/src/contexts/authHelpers.js
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+export const AUTH_KEY = 'auth-token';
+
+export const AuthContext = createContext();
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export function getBaseUrl() {
+  return (
+    (import.meta.env && import.meta.env.VITE_API_BASE_URL) ||
+    process.env.VITE_API_BASE_URL ||
+    ''
+  );
+}

--- a/src/screens/Login.jsx
+++ b/src/screens/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthProvider';
+import { useAuth } from '../contexts/authHelpers';
 
 export default function Login() {
   const { login } = useAuth();

--- a/src/screens/SignUp.jsx
+++ b/src/screens/SignUp.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthProvider';
+import { useAuth } from '../contexts/authHelpers';
 
 export default function SignUp() {
   const { register } = useAuth();


### PR DESCRIPTION
## Summary
- move auth context and helpers to `authHelpers.js`
- keep `AuthProvider.jsx` focused on component export
- update imports for `useAuth`
- document helper module in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685407a158e4832e85ed6f81cf29a16f