### PR TITLE
Use raw Unsplash photo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 `GET /api/photos?query=term` searches Unsplash and returns a 640×360 smart-cropped landscape photo.
 The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed.
-It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash URL so Imgix crops around faces or the most interesting region. If the original Unsplash link already includes query parameters, the cropping string is concatenated with `&` instead of `?`.
+It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash **raw** image URL so Imgix crops around faces or the most interesting region. If the original Unsplash link already includes query parameters, the cropping string is concatenated with `&` instead of `?`.
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
 Include a `format` query to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -35,7 +35,7 @@ describe('fetchCleanPhoto', () => {
   test('includes smart crop parameters', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { regular: 'http://img.test/a.jpg' } }] }),
+      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
     })
 
     const result = await fetchCleanPhoto('pug')

--- a/utils/fetchCleanPhoto.js
+++ b/utils/fetchCleanPhoto.js
@@ -25,11 +25,10 @@ export default async function fetchCleanPhoto(rawQuery) {
       }
       const data = await res.json();
       if (data.results && data.results[0] && data.results[0].urls) {
-        const { raw, regular } = data.results[0].urls;
-        if (raw || regular) {
-          const baseUrl = raw || regular;
-          const join = baseUrl.includes('?') ? '&' : '?';
-          return `${baseUrl}${join}${CROP_PARAMS}`;
+        const { raw } = data.results[0].urls;
+        if (raw) {
+          const join = raw.includes('?') ? '&' : '?';
+          return `${raw}${join}${CROP_PARAMS}`;
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- append crop params only to `urls.raw` in `fetchCleanPhoto`
- update tests for new cropping logic
- document raw Unsplash URL usage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685409780248832e84e831b4134ec9c2