### PR TITLE
Update Unsplash crop handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 ### Photo Search API
 
-`GET /api/photos?query=term` searches Unsplash and returns a 640×360 smart-cropped landscape photo.
+`GET /api/photos?query=term` searches Unsplash and returns a 640×360 face/entropy crop using the raw URL with Imgix parameters.
 Search terms are sanitized by trimming leading and trailing whitespace before contacting Unsplash.
 The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed.
 It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash **raw** image URL so Imgix crops around faces or the most interesting region. If the original Unsplash link already includes query parameters, the cropping string is concatenated with `&` instead of `?`.

--- a/server.js
+++ b/server.js
@@ -85,6 +85,7 @@ app.get('/api/photos', async (req, res) => {
       res.status(404).json({ detail: 'Unsplash request failed' });
       return;
     }
+    console.log('Unsplash final URL', photo);
     if (format) {
       res.json({ url: photo });
     } else {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -75,6 +75,7 @@ describe('photo endpoint', () => {
       .query({ query: 'cats' });
 
     expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-store');
     expect(res.body).toEqual({
       small: 'http://img.test/photo-small.jpg?w=640&h=360&fit=crop&crop=faces,entropy',
       regular:


### PR DESCRIPTION
## Summary
- describe API crop handling with raw URLs
- log the final Unsplash URL on `/api/photos`
- expect `Cache-Control: no-store` in `/api/photos` tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68540fd0e934832e9d45e4ebb0bfc4c3