### PR TITLE
Add Cache-Control header test for format param

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -162,6 +162,24 @@ describe('photo endpoint', () => {
     );
   });
 
+  test('sets Cache-Control header when format is provided', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          { urls: { raw: 'http://img.test/s.jpg' } },
+        ],
+      }),
+    });
+
+    const res = await request(app)
+      .get('/api/photos')
+      .query({ query: 'cat', format: 'regular' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
   test('requests compressed photo', async () => {
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- verify Cache-Control header when format parameter is provided

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685412cf8938832e9704b550a1acbb43