### PR TITLE
Update photo API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash **raw** ima
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
 Include a `format` query to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.
+Make sure this key is valid and that the server can reach `api.unsplash.com`. The `/api/photos` route requires outbound network access; network failures result in HTTP `502` responses.
+If you use a proxy or have restricted egress, set the appropriate environment variables (e.g. `HTTPS_PROXY`) so outbound requests to Unsplash succeed.
 If Unsplash has no results the endpoint responds with HTTP `404` and `{ "detail": "Unsplash request failed" }`.
 Network or server errors from Unsplash result in HTTP `502` with the same `detail` field and the underlying error code for troubleshooting.
 If the request fails on the client, the app falls back to `/images/placeholder.png`.


### PR DESCRIPTION
## Summary
- document `UNSPLASH_ACCESS_KEY` and outbound network needs for the photo API
- mention 502 errors on network failure and proxy troubleshooting tip

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685413af8018832e8820942b544a8f57