### PR TITLE
Use random Unsplash endpoint for varied photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 ### Photo Search API
 
-`GET /api/photos?query=term` searches Unsplash and returns a 640×360 face/entropy crop using the raw URL with Imgix parameters.
+`GET /api/photos?query=term` fetches a random Unsplash photo and returns a 640×360 face/entropy crop using the raw URL with Imgix parameters.
 Search terms are sanitized by trimming leading and trailing whitespace before contacting Unsplash.
-The server tries several search phrases with a white background and falls back to `/images/placeholder.png` if none succeed.
+The server tries a few search phrases and falls back to `/images/placeholder.png` if none succeed.
 It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash **raw** image URL so Imgix crops around faces or the most interesting region. If the original Unsplash link already includes query parameters, the cropping string is concatenated with `&` instead of `?`.
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
 Include a `format` query to receive a single `{ "url": "..." }` instead.

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -13,7 +13,7 @@ describe('fetchCleanPhoto', () => {
   test('returns first result', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
+      json: async () => ({ urls: { raw: 'http://img.test/a.jpg' } }),
     })
 
     await expect(fetchCleanPhoto('cats')).resolves.toBe(
@@ -24,7 +24,7 @@ describe('fetchCleanPhoto', () => {
   test('handles existing query strings', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg?foo=1' } }] }),
+      json: async () => ({ urls: { raw: 'http://img.test/a.jpg?foo=1' } }),
     })
 
     await expect(fetchCleanPhoto('cats')).resolves.toBe(
@@ -35,7 +35,7 @@ describe('fetchCleanPhoto', () => {
   test('includes smart crop parameters', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
+      json: async () => ({ urls: { raw: 'http://img.test/a.jpg' } }),
     })
 
     const result = await fetchCleanPhoto('pug')
@@ -46,7 +46,7 @@ describe('fetchCleanPhoto', () => {
   test('trims whitespace in query', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/d.jpg' } }] }),
+      json: async () => ({ urls: { raw: 'http://img.test/d.jpg' } }),
     })
 
     const result = await fetchCleanPhoto('  Dalmatian  ')
@@ -59,15 +59,15 @@ describe('fetchCleanPhoto', () => {
   test('falls back through queries', async () => {
     global.fetch = jest
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
       .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'Not found' })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [{ urls: { raw: 'dog.jpg' } }] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ urls: { raw: 'dog.jpg' } }) })
 
     const result = await fetchCleanPhoto('pug')
     expect(result).toBe('dog.jpg?w=640&h=360&fit=crop&crop=faces,entropy')
     expect(global.fetch).toHaveBeenCalledTimes(3)
     expect(global.fetch.mock.calls[0][0]).toContain('isolated')
-    expect(global.fetch.mock.calls[2][0]).toContain('dog%20white%20background')
+    expect(global.fetch.mock.calls[2][0]).toContain('pug')
   })
 
   test('returns placeholder on 404', async () => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -63,11 +63,7 @@ describe('photo endpoint', () => {
   test('returns photo URLs on success', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({
-        results: [
-          { urls: { raw: 'http://img.test/photo-small.jpg' } },
-        ],
-      }),
+      json: async () => ({ urls: { raw: 'http://img.test/photo-small.jpg' } }),
     });
 
     const res = await request(app)
@@ -87,11 +83,7 @@ describe('photo endpoint', () => {
   test('adds crop params with ampersand when query exists', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({
-        results: [
-          { urls: { raw: 'http://img.test/photo-small.jpg?foo=1' } },
-        ],
-      }),
+      json: async () => ({ urls: { raw: 'http://img.test/photo-small.jpg?foo=1' } }),
     });
 
     const res = await request(app)
@@ -116,11 +108,7 @@ describe('photo endpoint', () => {
     async (afrikaans, english) => {
       const spy = jest.spyOn(global, 'fetch').mockResolvedValue({
         ok: true,
-        json: async () => ({
-          results: [
-            { urls: { raw: `http://img.test/${english}.jpg` } },
-          ],
-        }),
+        json: async () => ({ urls: { raw: `http://img.test/${english}.jpg` } }),
       });
 
       const res = await request(app)
@@ -145,11 +133,7 @@ describe('photo endpoint', () => {
   test('returns requested format', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({
-        results: [
-          { urls: { raw: 'http://img.test/s.jpg' } },
-        ],
-      }),
+      json: async () => ({ urls: { raw: 'http://img.test/s.jpg' } }),
     });
 
     const res = await request(app)
@@ -165,11 +149,7 @@ describe('photo endpoint', () => {
   test('sets Cache-Control header when format is provided', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({
-        results: [
-          { urls: { raw: 'http://img.test/s.jpg' } },
-        ],
-      }),
+      json: async () => ({ urls: { raw: 'http://img.test/s.jpg' } }),
     });
 
     const res = await request(app)
@@ -183,9 +163,7 @@ describe('photo endpoint', () => {
   test('requests compressed photo', async () => {
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({
-        results: [{ urls: { raw: 's' } }],
-      }),
+      json: async () => ({ urls: { raw: 's' } }),
     });
 
     const res = await request(app)
@@ -195,7 +173,7 @@ describe('photo endpoint', () => {
     expect(res.status).toBe(200);
     const callUrl = spy.mock.calls[0][0];
     expect(callUrl).toContain('orientation=landscape');
-    expect(callUrl).toContain('per_page=1');
+    expect(callUrl).toContain('count=1');
     expect(callUrl).not.toContain('fit=crop');
 
     expect(res.body.small).toContain('w=640');
@@ -207,9 +185,7 @@ describe('photo endpoint', () => {
   test('trims query before sending to Unsplash', async () => {
     const spy = jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
-      json: async () => ({
-        results: [{ urls: { raw: 'http://img.test/dal.jpg' } }],
-      }),
+      json: async () => ({ urls: { raw: 'http://img.test/dal.jpg' } }),
     });
 
     const res = await request(app)

--- a/utils/fetchCleanPhoto.js
+++ b/utils/fetchCleanPhoto.js
@@ -1,6 +1,8 @@
 import { breedMap } from './breedMap.js';
 
-const UNSPLASH_URL = 'https://api.unsplash.com/search/photos';
+// Use the Unsplash random photo endpoint so repeated requests
+// yield different images even for the same search term.
+const UNSPLASH_URL = 'https://api.unsplash.com/photos/random';
 const CROP_PARAMS = 'w=640&h=360&fit=crop&crop=faces,entropy';
 
 export default async function fetchCleanPhoto(rawQuery) {
@@ -8,12 +10,12 @@ export default async function fetchCleanPhoto(rawQuery) {
   const queries = [
     `${term} isolated minimal background`,
     `${term} white background`,
-    'dog white background',
+    term,
   ];
 
   let lastError = null;
   for (const q of queries) {
-    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(q)}&color=white&orientation=landscape&per_page=1`;
+    const url = `${UNSPLASH_URL}?query=${encodeURIComponent(q)}&orientation=landscape&count=1`;
     try {
       const res = await fetch(url, {
         headers: { Authorization: `Client-ID ${process.env.UNSPLASH_ACCESS_KEY}` },
@@ -27,12 +29,13 @@ export default async function fetchCleanPhoto(rawQuery) {
         continue;
       }
       const data = await res.json();
-      if (data.results && data.results[0] && data.results[0].urls) {
-        const { raw } = data.results[0].urls;
-        if (raw) {
-          const join = raw.includes('?') ? '&' : '?';
-          return `${raw}${join}${CROP_PARAMS}`;
-        }
+      // The random endpoint returns either a single object or an array when
+      // the `count` parameter is used. Normalise it to a single photo object.
+      const photo = Array.isArray(data) ? data[0] : data;
+      if (photo && photo.urls && photo.urls.raw) {
+        const { raw } = photo.urls;
+        const join = raw.includes('?') ? '&' : '?';
+        return `${raw}${join}${CROP_PARAMS}`;
       }
     } catch (err) {
       console.error(`Fetch failed for "${q}"`, err);


### PR DESCRIPTION
## Summary
- switch photo fetch to use Unsplash random endpoint
- update tests for new Unsplash response format
- tweak documentation for new search behavior

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685418872c30832e8aeaa6e48612752c