### PR TITLE
Improve Unsplash photo relevance

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The frontend reads this value via the `__API_BASE_URL__` constant defined by Vit
 
 ### Photo Search API
 
-`GET /api/photos?query=term` fetches a random Unsplash photo and returns a 640×360 face/entropy crop using the raw URL with Imgix parameters.
+`GET /api/photos?query=term` fetches the first Unsplash search result and returns a 640×360 face/entropy crop using the raw URL with Imgix parameters.
 Search terms are sanitized by trimming leading and trailing whitespace before contacting Unsplash.
 The server tries a few search phrases and falls back to `/images/placeholder.png` if none succeed.
 It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash **raw** image URL so Imgix crops around faces or the most interesting region. If the original Unsplash link already includes query parameters, the cropping string is concatenated with `&` instead of `?`.

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -13,7 +13,7 @@ describe('fetchCleanPhoto', () => {
   test('returns first result', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ urls: { raw: 'http://img.test/a.jpg' } }),
+      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
     })
 
     await expect(fetchCleanPhoto('cats')).resolves.toBe(
@@ -24,7 +24,7 @@ describe('fetchCleanPhoto', () => {
   test('handles existing query strings', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ urls: { raw: 'http://img.test/a.jpg?foo=1' } }),
+      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg?foo=1' } }] }),
     })
 
     await expect(fetchCleanPhoto('cats')).resolves.toBe(
@@ -35,7 +35,7 @@ describe('fetchCleanPhoto', () => {
   test('includes smart crop parameters', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ urls: { raw: 'http://img.test/a.jpg' } }),
+      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
     })
 
     const result = await fetchCleanPhoto('pug')
@@ -46,7 +46,7 @@ describe('fetchCleanPhoto', () => {
   test('trims whitespace in query', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ urls: { raw: 'http://img.test/d.jpg' } }),
+      json: async () => ({ results: [{ urls: { raw: 'http://img.test/d.jpg' } }] }),
     })
 
     const result = await fetchCleanPhoto('  Dalmatian  ')
@@ -59,9 +59,9 @@ describe('fetchCleanPhoto', () => {
   test('falls back through queries', async () => {
     global.fetch = jest
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
       .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'Not found' })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ urls: { raw: 'dog.jpg' } }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [{ urls: { raw: 'dog.jpg' } }] }) })
 
     const result = await fetchCleanPhoto('pug')
     expect(result).toBe('dog.jpg?w=640&h=360&fit=crop&crop=faces,entropy')

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -173,7 +173,8 @@ describe('photo endpoint', () => {
     expect(res.status).toBe(200);
     const callUrl = spy.mock.calls[0][0];
     expect(callUrl).toContain('orientation=landscape');
-    expect(callUrl).toContain('count=1');
+    expect(callUrl).toContain('per_page=1');
+    expect(callUrl).toContain('/search/photos');
     expect(callUrl).not.toContain('fit=crop');
 
     expect(res.body.small).toContain('w=640');


### PR DESCRIPTION
## Summary
- switch to the Unsplash search API so queries return more relevant photos
- update unit tests for new search response format
- document the change in `README`

## Testing
- `npm install`
- `npx jest --runInBand tests`

------
https://chatgpt.com/codex/tasks/task_e_68541cb8151c832e919e3c220394dd38