### PR TITLE
Integrate fetchCleanPhoto into photo route

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,15 +175,10 @@ It appends `w=640&h=360&fit=crop&crop=faces,entropy` to the Unsplash **raw** ima
 Without extra parameters the response has the shape `{ "small": "url", "regular": "url" }` where both URLs are identical.
 Include a `format` query to receive a single `{ "url": "..." }` instead.
 The server requires `UNSPLASH_ACCESS_KEY` in the environment. Queries for Afrikaans dog breed names are translated to their English equivalents so Unsplash can find matching photos.
-Make sure this key is valid and that the server can reach `api.unsplash.com`. The `/api/photos` route requires outbound network access. If the request fails, the server falls back to `/images/placeholder.png` and responds with HTTP `404`.
+Make sure this key is valid and that the server can reach `api.unsplash.com`. The `/api/photos` route requires outbound network access. If the request fails or Unsplash has no matching photos, the server simply returns `/images/placeholder.png` with HTTP `200`.
 If you use a proxy or have restricted egress, set the appropriate environment variables (e.g. `HTTPS_PROXY`) so outbound requests to Unsplash succeed.
-If Unsplash has no results or a network error occurs, the endpoint responds with HTTP `404` and `{ "detail": "Unsplash request failed" }`.
+If Unsplash cannot provide a photo, you receive `{ "small": "/images/placeholder.png", "regular": "/images/placeholder.png" }`.
 
-```json
-{
-  "detail": "Unsplash request failed",
-}
-```
 If the request fails on the client, the app falls back to `/images/placeholder.png`.
 The file is not included in the repo; add your own placeholder image at `public/images/placeholder.png`.
 ### Interpreting Server Logs

--- a/server.js
+++ b/server.js
@@ -75,30 +75,26 @@ app.post('/api/register', async (req, res) => {
 app.get('/api/photos', async (req, res) => {
   const { query, format } = req.query;
   if (!query) {
-    res.status(400).json({ detail: 'Missing query parameter' });
-    return;
+    return res.status(400).json({ detail: 'Missing query parameter' });
   }
+
   res.set('Cache-Control', 'no-store');
+
   try {
-    const photo = await fetchCleanPhoto(query);
-    if (photo === '/images/placeholder.png') {
-      res.status(404).json({ detail: 'Unsplash request failed' });
-      return;
+    const photoUrl = await fetchCleanPhoto(query);
+    console.log('Unsplash final URL', photoUrl);
+
+    if (format === 'regular' || format === 'small') {
+      return res.json({ url: photoUrl });
     }
-    console.log('Unsplash final URL', photo);
-    if (format) {
-      res.json({ url: photo });
-    } else {
-      res.json({ small: photo, regular: photo });
-    }
+
+    return res.json({ small: photoUrl, regular: photoUrl });
   } catch (err) {
-    console.error('Fetch to Unsplash failed', err);
-    res
-      .status(502)
-      .json({
-        detail: 'Unsplash request failed',
-        error: err.code || err.message,
-      });
+    console.error('Failed to fetch photo:', err);
+    return res.status(502).json({
+      detail: 'Unsplash request failed',
+      error: err.code || err.message,
+    });
   }
 });
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -204,7 +204,7 @@ describe('photo endpoint', () => {
     );
   });
 
-  test('returns 404 when Unsplash has no results', async () => {
+  test('falls back to placeholder when Unsplash has no results', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: false,
       status: 404,
@@ -215,11 +215,14 @@ describe('photo endpoint', () => {
       .get('/api/photos')
       .query({ query: 'dogs' });
 
-    expect(res.status).toBe(404);
-    expect(res.body.detail).toBe('Unsplash request failed');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      small: '/images/placeholder.png',
+      regular: '/images/placeholder.png',
+    });
   });
 
-  test('returns 404 when fetch fails', async () => {
+  test('falls back to placeholder when fetch fails', async () => {
     jest
       .spyOn(global, 'fetch')
       .mockRejectedValue(Object.assign(new Error('fail'), { code: 'ENETUNREACH' }));
@@ -228,7 +231,10 @@ describe('photo endpoint', () => {
       .get('/api/photos')
       .query({ query: 'dogs' });
 
-    expect(res.status).toBe(404);
-    expect(res.body.detail).toBe('Unsplash request failed');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      small: '/images/placeholder.png',
+      regular: '/images/placeholder.png',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- refactor `/api/photos` to always use `fetchCleanPhoto`
- simplify route responses and return placeholder with 200
- document new behavior in README
- update tests for photo endpoint

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68542108ca84832e8a52a6d1eaa25b53