### PR TITLE
Improve photo fetching logic with detailed logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,27 +74,22 @@ app.post('/api/register', async (req, res) => {
 
 app.get('/api/photos', async (req, res) => {
   const { query, format } = req.query;
-  if (!query) {
-    return res.status(400).json({ detail: 'Missing query parameter' });
-  }
+  if (!query) return res.status(400).json({ detail: 'Missing query parameter' });
 
   res.set('Cache-Control', 'no-store');
 
   try {
     const photoUrl = await fetchCleanPhoto(query);
-    console.log('Unsplash final URL', photoUrl);
 
     if (format === 'regular' || format === 'small') {
       return res.json({ url: photoUrl });
     }
-
     return res.json({ small: photoUrl, regular: photoUrl });
   } catch (err) {
-    console.error('Failed to fetch photo:', err);
-    return res.status(502).json({
-      detail: 'Unsplash request failed',
-      error: err.code || err.message,
-    });
+    console.error('Unexpected error in /api/photos:', err);
+    return res
+      .status(502)
+      .json({ detail: 'Unsplash request failed', error: err.message });
   }
 });
 

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -13,46 +13,40 @@ describe('fetchCleanPhoto', () => {
   test('returns first result', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
+      json: async () => ({ results: [{ urls: { small: 'http://img.test/a.jpg' } }] }),
     })
 
-    await expect(fetchCleanPhoto('cats')).resolves.toBe(
-      'http://img.test/a.jpg?w=640&h=360&fit=crop&crop=faces,entropy',
-    )
+    await expect(fetchCleanPhoto('cats')).resolves.toBe('http://img.test/a.jpg')
   })
 
   test('handles existing query strings', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg?foo=1' } }] }),
+      json: async () => ({ results: [{ urls: { small: 'http://img.test/a.jpg?foo=1' } }] }),
     })
 
-    await expect(fetchCleanPhoto('cats')).resolves.toBe(
-      'http://img.test/a.jpg?foo=1&w=640&h=360&fit=crop&crop=faces,entropy',
-    )
+    await expect(fetchCleanPhoto('cats')).resolves.toBe('http://img.test/a.jpg?foo=1')
   })
 
-  test('includes smart crop parameters', async () => {
+  test('includes crop params in API request', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/a.jpg' } }] }),
+      json: async () => ({ results: [{ urls: { small: 'http://img.test/a.jpg' } }] }),
     })
 
-    const result = await fetchCleanPhoto('pug')
-    expect(result).toContain('fit=crop')
-    expect(result).toContain('crop=faces,entropy')
+    await fetchCleanPhoto('pug')
+    expect(global.fetch.mock.calls[0][0]).toContain('fit=crop')
+    expect(global.fetch.mock.calls[0][0]).toContain('crop=faces,entropy')
   })
 
   test('trims whitespace in query', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ results: [{ urls: { raw: 'http://img.test/d.jpg' } }] }),
+      json: async () => ({ results: [{ urls: { small: 'http://img.test/d.jpg' } }] }),
     })
 
     const result = await fetchCleanPhoto('  Dalmatian  ')
-    expect(result).toBe(
-      'http://img.test/d.jpg?w=640&h=360&fit=crop&crop=faces,entropy',
-    )
+    expect(result).toBe('http://img.test/d.jpg')
     expect(global.fetch.mock.calls[0][0]).toContain('Dalmatian')
   })
 
@@ -62,13 +56,13 @@ describe('fetchCleanPhoto', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [] }) })
       .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'Not found' })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [{ urls: { raw: 'dog.jpg' } }] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ results: [{ urls: { small: 'dog.jpg' } }] }) })
 
     const result = await fetchCleanPhoto('pug')
-    expect(result).toBe('dog.jpg?w=640&h=360&fit=crop&crop=faces,entropy')
+    expect(result).toBe('dog.jpg')
     expect(global.fetch).toHaveBeenCalledTimes(4)
     expect(global.fetch.mock.calls[0][0]).toContain('orientation=portrait')
-    expect(global.fetch.mock.calls[1][0]).toContain('white+background')
+    expect(global.fetch.mock.calls[1][0]).toContain('color=white')
     expect(global.fetch.mock.calls[2][0]).toContain('isolated')
     expect(global.fetch.mock.calls[3][0]).toContain('pug')
   })


### PR DESCRIPTION
## Summary
- enhance `fetchCleanPhoto` queries and add detailed logging
- hook updated helper into `/api/photos`
- adjust unit tests for new photo fetching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854224435fc832ea3e8218569474596