### PR TITLE
Add missing encyclopedia placeholder images

### DIFF
--- a/public/images/encyclopedia/abbesinier-kat.svg
+++ b/public/images/encyclopedia/abbesinier-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Abbesiniér kat</text></svg>

--- a/public/images/encyclopedia/afghaanse-hond.svg
+++ b/public/images/encyclopedia/afghaanse-hond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Afgaanse hond</text></svg>

--- a/public/images/encyclopedia/bloedhond.svg
+++ b/public/images/encyclopedia/bloedhond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bloedhond</text></svg>

--- a/public/images/encyclopedia/bulhond.svg
+++ b/public/images/encyclopedia/bulhond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bulhond</text></svg>

--- a/public/images/encyclopedia/chinchilla-kat.svg
+++ b/public/images/encyclopedia/chinchilla-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Chinchilla kat</text></svg>

--- a/public/images/encyclopedia/dalmatiese-hond.svg
+++ b/public/images/encyclopedia/dalmatiese-hond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dalmatiese hond</text></svg>

--- a/public/images/encyclopedia/dashond.svg
+++ b/public/images/encyclopedia/dashond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dashond</text></svg>

--- a/public/images/encyclopedia/engelse-patryshond.svg
+++ b/public/images/encyclopedia/engelse-patryshond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Engelse Patryshond</text></svg>

--- a/public/images/encyclopedia/franse-dashond.svg
+++ b/public/images/encyclopedia/franse-dashond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Franse Dashond</text></svg>

--- a/public/images/encyclopedia/goudkleurige-apporteerhond.svg
+++ b/public/images/encyclopedia/goudkleurige-apporteerhond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Goudkleurige Apporteerhond</text></svg>

--- a/public/images/encyclopedia/jagwindhond.svg
+++ b/public/images/encyclopedia/jagwindhond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Jagwindhond</text></svg>

--- a/public/images/encyclopedia/maine-coon.svg
+++ b/public/images/encyclopedia/maine-coon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Maine Coon</text></svg>

--- a/public/images/encyclopedia/ragdoll-kat.svg
+++ b/public/images/encyclopedia/ragdoll-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Ragdoll kat</text></svg>

--- a/public/images/encyclopedia/rhodesiese-rifrughond.svg
+++ b/public/images/encyclopedia/rhodesiese-rifrughond.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rhodesiese Rifrughond</text></svg>

--- a/public/images/encyclopedia/rob-bruin-himalajan-kat.svg
+++ b/public/images/encyclopedia/rob-bruin-himalajan-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rob bruin Himalajan kat</text></svg>

--- a/public/images/encyclopedia/rokerige-swart-persiese-kat.svg
+++ b/public/images/encyclopedia/rokerige-swart-persiese-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rokerige Swart Persiese kat</text></svg>

--- a/public/images/encyclopedia/rooi-persiese-kat.svg
+++ b/public/images/encyclopedia/rooi-persiese-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rooi Persiese kat</text></svg>

--- a/public/images/encyclopedia/siamese-kat.svg
+++ b/public/images/encyclopedia/siamese-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Siamese kat</text></svg>

--- a/public/images/encyclopedia/turkse-angora-kat.svg
+++ b/public/images/encyclopedia/turkse-angora-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Turkse Angora kat</text></svg>

--- a/public/images/encyclopedia/turkse-van-kat.svg
+++ b/public/images/encyclopedia/turkse-van-kat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Turkse Van kat</text></svg>

--- a/scripts/generate_placeholders.cjs
+++ b/scripts/generate_placeholders.cjs
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+const weeks = ['public/weeks/week001.json', 'public/weeks/week002.json'];
+const outDir = 'public/images/encyclopedia';
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+const slugs = new Map();
+for (const file of weeks) {
+  const data = JSON.parse(fs.readFileSync(file));
+  data.encyclopedia.forEach(({ id, title }) => {
+    if (!slugs.has(id)) slugs.set(id, title);
+  });
+}
+for (const [slug, title] of slugs.entries()) {
+  const filePath = path.join(outDir, `${slug}.svg`);
+  if (fs.existsSync(filePath)) continue;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">${title}</text></svg>`;
+  fs.writeFileSync(filePath, svg);
+  console.log('created', filePath);
+}


### PR DESCRIPTION
## Summary
- generate placeholder SVGs for all encyclopedia entries
- add helper script to create placeholders

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685465744b78832e99144fc27a5763a3