### PR TITLE
Add warning for invalid week navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ random order while the upper five stay sequential.
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
-Parents can also jump to any of the 46 weeks from the Dashboard. Selecting a week loads its curriculum or displays "empty" if no data exists.
+Parents can also jump to any of the 46 weeks from the Dashboard. Selecting a week loads its curriculum or displays "empty" if no data exists. If you try to jump outside the available range, the app logs a warning in the browser console.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.
 Daily modules are listed in a small table labelled **"Weekly progress"**, where completed cells appear green.
 

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -103,6 +103,8 @@ export const ContentProvider = ({ children }) => {
   const jumpToWeek = (week) => {
     if (week >= 1 && week <= TOTAL_WEEKS) {
       saveProgress({ week, day: 1, session: 1 })
+    } else {
+      console.warn(`Week ${week} is out of range (1-${TOTAL_WEEKS})`)
     }
   }
 

--- a/src/contexts/ContentProvider.test.jsx
+++ b/src/contexts/ContentProvider.test.jsx
@@ -160,7 +160,7 @@ describe('jumpToWeek', () => {
     expect(stored.session).toBe(1)
   })
 
-  it('ignores out-of-range weeks', () => {
+  it('warns when week is out of range', () => {
     const Invalid = () => {
       const { progress, jumpToWeek } = useContent();
       return (
@@ -173,6 +173,8 @@ describe('jumpToWeek', () => {
       );
     };
 
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     render(
       <ContentProvider>
         <Invalid />
@@ -181,6 +183,11 @@ describe('jumpToWeek', () => {
 
     fireEvent.click(screen.getByText('bad'));
     expect(screen.getByTestId('week-invalid')).toHaveTextContent('1');
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Week ${TOTAL_WEEKS + 1} is out of range (1-${TOTAL_WEEKS})`,
+    );
+
+    warnSpy.mockRestore();
   });
 })
 


### PR DESCRIPTION
## Summary
- warn if `jumpToWeek` receives an out-of-range value
- document dashboard warning behaviour in README
- test the warning message

## Testing
- `npm run lint`
- `npx jest tests --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6854f45d86a8832e9b6532caae6d3b34