### PR TITLE
Handle course completion in progress tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Each file defines three keys:
 - `encyclopedia` – array of fact objects with `id`, `title`, `query`, `fact` and `image`
 
 The application loads weeks 1–46. When adding or removing weeks, update the
-`TOTAL_WEEKS` constant in `src/contexts/ContentProvider.jsx`.
+`TOTAL_WEEKS` constant in `src/contexts/ContentProvider.jsx`. Completing the
+final week keeps progress locked at week 46 and logs **"Course Finished!"** in
+the browser console.
 
 ## Progress Storage
 

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -82,12 +82,16 @@ export const ContentProvider = ({ children }) => {
     if (session < 3) {
       session += 1
     } else {
-      session = 1
       if (day < 7) {
         day += 1
-      } else {
-        day = 1
+        session = 1
+      } else if (week < TOTAL_WEEKS) {
         week += 1
+        day = 1
+        session = 1
+      } else {
+        console.log('Course Finished!')
+        // keep week/day/session at final values
       }
       streak += 1
     }

--- a/src/contexts/ContentProvider.test.jsx
+++ b/src/contexts/ContentProvider.test.jsx
@@ -255,3 +255,40 @@ describe('reset helpers', () => {
     expect(window.confirm).toHaveBeenCalled()
   })
 })
+
+describe('completeSession final week', () => {
+  it('keeps week at TOTAL_WEEKS and logs message', () => {
+    localStorage.setItem(
+      'progress-v1',
+      JSON.stringify({ version: 1, week: TOTAL_WEEKS, day: 7, session: 3, streak: 5 }),
+    )
+
+    const Consumer = () => {
+      const { progress, completeSession } = useContent()
+      return (
+        <div>
+          <span data-testid="week">{progress.week}</span>
+          <button type="button" onClick={completeSession}>
+            do
+          </button>
+        </div>
+      )
+    }
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    render(
+      <ContentProvider>
+        <Consumer />
+      </ContentProvider>,
+    )
+
+    fireEvent.click(screen.getByText('do'))
+    expect(screen.getByTestId('week')).toHaveTextContent(String(TOTAL_WEEKS))
+    const stored = JSON.parse(localStorage.getItem('progress-v1'))
+    expect(stored.week).toBe(TOTAL_WEEKS)
+    expect(logSpy).toHaveBeenCalledWith('Course Finished!')
+
+    logSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- stop progress at `TOTAL_WEEKS`
- log `Course Finished!` when the last week is done
- document course completion behaviour
- test final-week completion logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685505dd2198832e8a3258930d53a666