### PR TITLE
Implement week start confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ random order while the upper five stay sequential.
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
-Parents can also jump to any of the 46 weeks from the Dashboard. Selecting a week loads its curriculum or displays "empty" if no data exists. If you try to jump outside the available range, the app logs a warning in the browser console.
+Parents can also jump to any of the 46 weeks from the Dashboard. Selecting a week now shows a short confirmation asking whether to start that session. Accepting jumps directly to the session while cancelling keeps you on the Dashboard. If you try to jump outside the available range, the app logs a warning in the browser console.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.
 Daily modules are listed in a small table labelled **"Weekly progress"**, where completed cells appear green.
 

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useContent, TOTAL_WEEKS } from '../contexts/ContentProvider'
 import NavBar from '../components/NavBar'
 import DashboardHeader from '../components/DashboardHeader'
@@ -8,6 +9,8 @@ const PIN = '1234'
 const Dashboard = () => {
   const [entered, setEntered] = useState('')
   const [unlocked, setUnlocked] = useState(false)
+  const [confirmWeek, setConfirmWeek] = useState(null)
+  const navigate = useNavigate()
 
   const {
     progress,
@@ -99,7 +102,7 @@ const Dashboard = () => {
             data-testid={`week-btn-${w}`}
             className={`border p-1 rounded hover:bg-indigo-100 ${w === progress.week ? 'bg-indigo-200 font-bold' : ''}`}
             aria-current={w === progress.week ? 'true' : undefined}
-            onClick={() => jumpToWeek(w)}
+            onClick={() => setConfirmWeek(w)}
           >
             {w}
           </button>
@@ -129,6 +132,29 @@ const Dashboard = () => {
           📜 Print Certificate
         </button>
       </div>
+      {confirmWeek && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center" data-testid="week-confirm">
+          <div className="bg-white p-4 rounded space-y-2 text-center shadow">
+            <p>Start Week {confirmWeek}?</p>
+            <div className="flex justify-center gap-2">
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  jumpToWeek(confirmWeek)
+                  setConfirmWeek(null)
+                  navigate('/session')
+                }}
+              >
+                Yes
+              </button>
+              <button type="button" className="btn" onClick={() => setConfirmWeek(null)}>
+                No
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       </div>
     </>
   )

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -5,7 +5,17 @@ import Dashboard from './Dashboard'
 import { useContent } from '../contexts/ContentProvider'
 const { TOTAL_WEEKS } = jest.requireActual('../contexts/ContentProvider')
 
+const mockNavigate = jest.fn()
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
 jest.mock('../contexts/ContentProvider')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
 
 describe('Dashboard', () => {
   it('PIN input uses responsive width classes', () => {
@@ -88,7 +98,10 @@ describe('Dashboard', () => {
 
     expect(screen.getByTestId(`week-btn-${TOTAL_WEEKS}`)).toBeInTheDocument()
     fireEvent.click(screen.getByTestId(`week-btn-${TOTAL_WEEKS}`))
+    expect(screen.getByTestId('week-confirm')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /yes/i }))
     expect(jumpToWeek).toHaveBeenCalledWith(TOTAL_WEEKS)
+    expect(mockNavigate).toHaveBeenCalledWith('/session')
   })
 
   it('uses responsive classes for week grid', () => {


### PR DESCRIPTION
## Summary
- ask for confirmation when jumping to a different week
- navigate to the session when confirmed
- test week confirmation flow
- document new behavior in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685507802c98832e979c1b06d1547e45