### PR TITLE
Fix week selection overlay logic

### DIFF
--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -132,7 +132,7 @@ const Dashboard = () => {
           📜 Print Certificate
         </button>
       </div>
-      {confirmWeek && (
+      {confirmWeek !== null && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center" data-testid="week-confirm">
           <div className="bg-white p-4 rounded space-y-2 text-center shadow">
             <p>Start Week {confirmWeek}?</p>


### PR DESCRIPTION
## Summary
- show confirmation dialog if selected week is 0
- maintain routing on week selection

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550dd44594832e891dc4b90d2f44c9