### PR TITLE
Improve week grid buttons

### DIFF
--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -100,7 +100,7 @@ const Dashboard = () => {
             key={w}
             type="button"
             data-testid={`week-btn-${w}`}
-            className={`border p-1 rounded hover:bg-indigo-100 ${w === progress.week ? 'bg-indigo-200 font-bold' : ''}`}
+            className={`border p-1 rounded hover:bg-indigo-100 cursor-pointer ${w === progress.week ? 'bg-indigo-200 font-bold' : ''}`}
             aria-current={w === progress.week ? 'true' : undefined}
             onClick={() => setConfirmWeek(w)}
           >

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -183,6 +183,7 @@ describe('Dashboard', () => {
     expect(active).toHaveAttribute('aria-current', 'true')
     expect(active).toHaveClass('font-bold')
     expect(active).toHaveClass('hover:bg-indigo-100')
+    expect(active).toHaveClass('cursor-pointer')
   })
 
   it('renders control buttons with emoji labels', () => {


### PR DESCRIPTION
## Summary
- add cursor pointer styling for week buttons
- check pointer class in dashboard tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68550f496b78832e8866cb6405ec1edd