### PR TITLE
Add session confirmation overlay

### DIFF
--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -9,6 +9,7 @@ const PIN = '1234'
 const Dashboard = () => {
   const [entered, setEntered] = useState('')
   const [unlocked, setUnlocked] = useState(false)
+  const [confirmWeek, setConfirmWeek] = useState(null)
   const navigate = useNavigate()
 
   const {
@@ -101,10 +102,7 @@ const Dashboard = () => {
             data-testid={`week-btn-${w}`}
             className={`border p-1 rounded hover:bg-indigo-100 cursor-pointer ${w === progress.week ? 'bg-indigo-200 font-bold' : ''}`}
             aria-current={w === progress.week ? 'true' : undefined}
-            onClick={() => {
-              jumpToWeek(w)
-              navigate('/session')
-            }}
+            onClick={() => setConfirmWeek(w)}
           >
             {w}
           </button>
@@ -134,7 +132,30 @@ const Dashboard = () => {
           📜 Print Certificate
         </button>
       </div>
+      {confirmWeek !== null && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center" data-testid="week-confirm">
+          <div className="bg-white p-4 rounded space-y-2 text-center shadow">
+            <p>Continue to session?</p>
+            <div className="flex justify-center gap-2">
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  jumpToWeek(confirmWeek)
+                  setConfirmWeek(null)
+                  navigate('/session')
+                }}
+              >
+                Continue
+              </button>
+              <button type="button" className="btn" onClick={() => setConfirmWeek(null)}>
+                Cancel
+              </button>
+            </div>
+          </div>
         </div>
+      )}
+      </div>
       </>
     )
 }

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -98,7 +98,8 @@ describe('Dashboard', () => {
 
     expect(screen.getByTestId(`week-btn-${TOTAL_WEEKS}`)).toBeInTheDocument()
     fireEvent.click(screen.getByTestId(`week-btn-${TOTAL_WEEKS}`))
-    expect(screen.queryByTestId('week-confirm')).not.toBeInTheDocument()
+    expect(screen.getByTestId('week-confirm')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
     expect(jumpToWeek).toHaveBeenCalledWith(TOTAL_WEEKS)
     expect(mockNavigate).toHaveBeenCalledWith('/session')
   })


### PR DESCRIPTION
## Summary
- add `confirmWeek` overlay with Continue/Cancel
- update week button click to open confirmation
- adjust dashboard tests for new overlay behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68551193f4a0832ebcf7d84503dcd73d