### PR TITLE
Fix week confirm panel placement and auto-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ random order while the upper five stay sequential.
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
-Parents can also jump to any of the 46 weeks from the Dashboard. Selecting a week now reveals a simple confirmation panel with **Continue** and **Cancel** buttons. Choosing Continue jumps directly to the session while Cancel keeps you on the Dashboard. If you try to jump outside the available range, the app logs a warning in the browser console.
+Parents can also jump to any of the 46 weeks from the Dashboard. Selecting a week now reveals a simple confirmation panel with **Continue** and **Cancel** buttons. The page automatically scrolls this panel into view so parents don't miss it on long lists. Choosing Continue jumps directly to the session while Cancel keeps you on the Dashboard. If you try to jump outside the available range, the app logs a warning in the browser console.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.
 Daily modules are listed in a small table labelled **"Weekly progress"**, where completed cells appear green.
 

--- a/src/screens/Dashboard.jsx
+++ b/src/screens/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useContent, TOTAL_WEEKS } from '../contexts/ContentProvider'
 import NavBar from '../components/NavBar'
@@ -10,6 +10,13 @@ const Dashboard = () => {
   const [entered, setEntered] = useState('')
   const [unlocked, setUnlocked] = useState(false)
   const [confirmWeek, setConfirmWeek] = useState(null)
+  const confirmRef = useRef(null)
+
+  useEffect(() => {
+    if (confirmWeek !== null && confirmRef.current) {
+      confirmRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [confirmWeek])
   const navigate = useNavigate()
 
   const {
@@ -134,27 +141,26 @@ const Dashboard = () => {
       </div>
       {confirmWeek !== null && (
         <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          className="p-4 mt-4 bg-white rounded shadow space-y-2"
           data-testid="week-confirm"
+          ref={confirmRef}
         >
-          <div className="p-4 bg-white rounded shadow space-y-2">
-            <p>Continue to session?</p>
-            <div className="flex justify-center gap-2">
-              <button
-                type="button"
-                className="btn"
-                onClick={() => {
-                  jumpToWeek(confirmWeek)
-                  setConfirmWeek(null)
-                  navigate('/session')
-                }}
-              >
-                Continue
-              </button>
-              <button type="button" className="btn" onClick={() => setConfirmWeek(null)}>
-                Cancel
-              </button>
-            </div>
+          <p>Continue to session?</p>
+          <div className="flex justify-center gap-2">
+            <button
+              type="button"
+              className="btn"
+              onClick={() => {
+                jumpToWeek(confirmWeek)
+                setConfirmWeek(null)
+                navigate('/session')
+              }}
+            >
+              Continue
+            </button>
+            <button type="button" className="btn" onClick={() => setConfirmWeek(null)}>
+              Cancel
+            </button>
           </div>
         </div>
       )}

--- a/src/screens/Dashboard.test.jsx
+++ b/src/screens/Dashboard.test.jsx
@@ -13,8 +13,11 @@ jest.mock('react-router-dom', () => {
 
 jest.mock('../contexts/ContentProvider')
 
+const origScroll = HTMLElement.prototype.scrollIntoView
+
 afterEach(() => {
   jest.clearAllMocks()
+  HTMLElement.prototype.scrollIntoView = origScroll
 })
 
 describe('Dashboard', () => {
@@ -75,6 +78,8 @@ describe('Dashboard', () => {
 
   it('shows week buttons and jumps to week', () => {
     const jumpToWeek = jest.fn()
+    const scrollMock = jest.fn()
+    HTMLElement.prototype.scrollIntoView = scrollMock
     useContent.mockReturnValue({
       progress: { week: 1, day: 1, session: 1 },
       resetToday: jest.fn(),
@@ -99,6 +104,7 @@ describe('Dashboard', () => {
     expect(screen.getByTestId(`week-btn-${TOTAL_WEEKS}`)).toBeInTheDocument()
     fireEvent.click(screen.getByTestId(`week-btn-${TOTAL_WEEKS}`))
     expect(screen.getByTestId('week-confirm')).toBeInTheDocument()
+    expect(scrollMock).toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: /continue/i }))
     expect(jumpToWeek).toHaveBeenCalledWith(TOTAL_WEEKS)
     expect(mockNavigate).toHaveBeenCalledWith('/session')


### PR DESCRIPTION
## Summary
- revert dashboard week confirm overlay to inline panel
- auto-scroll to confirm panel when selecting a week
- test that the dashboard scrolls to the confirm panel
- document auto-scroll behavior in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68551b4c051c832eb48a054c46777daf