### PR TITLE
Add term grouping logic and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ The application loads weeks 1–46. When adding or removing weeks, update the
 final week keeps progress locked at week 46 and logs **"Course Finished!"** in
 the browser console.
 
+Weeks are grouped into four terms of twelve weeks each. The helper
+`getTermForWeek` in `src/utils/termHelpers.js` converts a week number to its
+term, using the `WEEKS_PER_TERM` constant.
+
 ## Progress Storage
 
 User progress is stored in `localStorage` under the key `progress-v1`. Each saved record contains a `version` field. If the stored version does not match the current application version, progress is reset to defaults. Bump the version when changing the progress schema.

--- a/src/components/DashboardHeader.jsx
+++ b/src/components/DashboardHeader.jsx
@@ -1,13 +1,15 @@
 import ProgressStrip from './ProgressStrip';
 import { useContent } from '../contexts/ContentProvider';
+import { getTermForWeek } from '../utils/termHelpers';
 
 const DashboardHeader = () => {
   const { progress } = useContent();
   const { week, day, session, streak } = progress;
+  const term = getTermForWeek(week);
   return (
     <div className="text-center space-y-2">
       <h1 className="text-3xl font-bold">
-        Week {week} · Day {day} · Session {session}
+        Term {term} · Week {week} · Day {day} · Session {session}
       </h1>
       <ProgressStrip />
       <p className="text-lg font-semibold" data-testid="streak">

--- a/src/components/DashboardHeader.test.jsx
+++ b/src/components/DashboardHeader.test.jsx
@@ -10,7 +10,7 @@ describe('DashboardHeader', () => {
 
     render(<DashboardHeader />);
 
-    expect(screen.getAllByText('Week 2 \u00B7 Day 3 \u00B7 Session 1')).toHaveLength(2);
+    expect(screen.getAllByText('Term 1 \u00B7 Week 2 \u00B7 Day 3 \u00B7 Session 1')).toHaveLength(2);
     expect(screen.getByTestId('streak')).toHaveTextContent('Streak: 4');
 
     const dots = screen.getAllByTestId('session-dot');

--- a/src/utils/termHelpers.js
+++ b/src/utils/termHelpers.js
@@ -1,0 +1,9 @@
+export const WEEKS_PER_TERM = 12;
+export const TOTAL_TERMS = 4;
+
+export function getTermForWeek(week) {
+  if (week < 1) {
+    return 1;
+  }
+  return Math.ceil(week / WEEKS_PER_TERM);
+}

--- a/tests/termHelpers.test.js
+++ b/tests/termHelpers.test.js
@@ -1,0 +1,16 @@
+import { getTermForWeek } from '../src/utils/termHelpers.js';
+
+describe('getTermForWeek', () => {
+  test.each([
+    [1, 1],
+    [12, 1],
+    [13, 2],
+    [24, 2],
+    [25, 3],
+    [36, 3],
+    [37, 4],
+    [46, 4],
+  ])('week %i is in term %i', (week, term) => {
+    expect(getTermForWeek(week)).toBe(term);
+  });
+});


### PR DESCRIPTION
## Summary
- add `getTermForWeek` helper with constants
- display current term in `DashboardHeader`
- update `DashboardHeader` tests
- document term grouping in README
- add tests for term helper

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553983ed28832e9d95c77378543dfd