### PR TITLE
Fix dot count position

### DIFF
--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -34,7 +34,7 @@ const Carousel = ({ items, renderItem }) => {
 
   return (
     <div className="space-y-4" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
-      <div className="card flex items-center justify-center min-h-[50vh]">
+      <div className="card relative flex items-center justify-center min-h-[50vh]">
         {renderItem(items[index])}
       </div>
       <div className="flex justify-between">

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -26,27 +26,29 @@ const MathModule = ({ start, length = 10, shuffleFirstHalf }) => {
       renderItem={(n) => {
         const positions = generateDotPositions(n)
         return (
-          <div className="relative w-full h-[60vw] sm:h-[40vh]">
+          <>
+            <div className="relative w-full h-[60vw] sm:h-[40vh]">
+              {positions.map((pos, i) => (
+                <span
+                  key={i}
+                  className="absolute inline-block rounded-full"
+                  style={{
+                    width: '1rem',
+                    height: '1rem',
+                    top: pos.top,
+                    left: pos.left,
+                    backgroundColor: '#ef4444',
+                  }}
+                />
+              ))}
+            </div>
             <span
               data-testid="dot-count"
               className="absolute top-0 right-0 m-1 text-[10px] text-black"
             >
               {n}
             </span>
-            {positions.map((pos, i) => (
-              <span
-                key={i}
-                className="absolute inline-block rounded-full"
-                style={{
-                  width: '1rem',
-                  height: '1rem',
-                  top: pos.top,
-                  left: pos.left,
-                  backgroundColor: '#ef4444',
-                }}
-              />
-            ))}
-          </div>
+          </>
         )
       }}
     />

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -10,7 +10,9 @@ describe('MathModule', () => {
 
   it('renders visible dots for each math slide', () => {
     const { container } = render(<MathModule start={1} />);
-    const board = container.querySelector('.relative');
+    const card = container.querySelector('.card');
+    expect(card).not.toBeNull();
+    const board = card.querySelector('div.relative');
     expect(board).not.toBeNull();
     const dots = board.querySelectorAll('span');
     expect(dots.length).toBeGreaterThan(0);
@@ -26,6 +28,15 @@ describe('MathModule', () => {
     render(<MathModule start={1} length={3} />);
     const counter = screen.getByTestId('dot-count');
     expect(counter).toHaveTextContent('1');
+  });
+
+  it('positions the dot count at the top right', () => {
+    render(<MathModule start={1} length={3} />);
+    const counter = screen.getByTestId('dot-count');
+    const styles = getComputedStyle(counter);
+    expect(styles.position).toBe('absolute');
+    expect(styles.top).toBe('0px');
+    expect(styles.right).toBe('0px');
   });
 
   describe('createSlides', () => {


### PR DESCRIPTION
## Summary
- make carousel card container relative
- position math dot count element after the dot board
- update MathModule tests for new layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554e451b48832eafe810a2a7da21e1