### PR TITLE
Fix dot count location

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ progress.
 
 The math module's red dots are styled inline with explicit dimensions so they
 remain visible even if Tailwind utilities are unavailable. A tiny black number
-in the top-right corner (about 10&nbsp;px) shows how many dots appear on the
-current slide. Term&nbsp;1 now introduces numbers gradually:
+is absolutely positioned in the slide's top-right corner (about 10&nbsp;px) so
+it never shifts when the dot board is centered. The count indicates how many
+dots appear on the current slide. Term&nbsp;1 now introduces numbers gradually:
 
 - **Week&nbsp;1** – numbers 1–5 in order
 - **Week&nbsp;2** – numbers 1–5 shuffled, followed by 6–10

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -26,27 +26,29 @@ const MathModule = ({ start, length = 10, shuffleFirstHalf }) => {
       renderItem={(n) => {
         const positions = generateDotPositions(n)
         return (
-          <div className="relative w-full h-[60vw] sm:h-[40vh]">
+          <>
             <span
               data-testid="dot-count"
               className="absolute top-0 right-0 m-1 text-[10px] text-black"
             >
               {n}
             </span>
-            {positions.map((pos, i) => (
-              <span
-                key={i}
-                className="absolute inline-block rounded-full"
-                style={{
-                  width: '1rem',
-                  height: '1rem',
-                  top: pos.top,
-                  left: pos.left,
-                  backgroundColor: '#ef4444',
-                }}
-              />
-            ))}
-          </div>
+            <div className="relative w-full h-[60vw] sm:h-[40vh]">
+              {positions.map((pos, i) => (
+                <span
+                  key={i}
+                  className="absolute inline-block rounded-full"
+                  style={{
+                    width: '1rem',
+                    height: '1rem',
+                    top: pos.top,
+                    left: pos.left,
+                    backgroundColor: '#ef4444',
+                  }}
+                />
+              ))}
+            </div>
+          </>
         )
       }}
     />

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -39,12 +39,13 @@ describe('MathModule', () => {
     expect(styles.right).toBe('0px');
   });
 
-  it('nests the dot count inside the board container', () => {
+  it('positions the dot count relative to the slide container', () => {
     const { container } = render(<MathModule start={1} length={3} />);
     const card = container.querySelector('.card');
     const board = card.querySelector('div.relative');
     const counter = screen.getByTestId('dot-count');
-    expect(board.contains(counter)).toBe(true);
+    expect(card.contains(counter)).toBe(true);
+    expect(board.contains(counter)).toBe(false);
   });
 
   describe('createSlides', () => {


### PR DESCRIPTION
## Summary
- show math dot count in the card's corner
- clarify README about dot count placement
- update tests for the new layout

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_685553361854832e87fed3b095241413