### PR TITLE
Fix week 13 math window

### DIFF
--- a/public/terms/term2/weeks/week013.json
+++ b/public/terms/term2/weeks/week013.json
@@ -6,7 +6,7 @@
     "pienk",
     "goud"
   ],
-  "mathWindowStart": 61,
+  "mathWindowStart": 60,
   "encyclopedia": [
     {
       "id": "afghaanse-hond",


### PR DESCRIPTION
## Summary
- adjust week 13 math window to start at 60 so dot range is 60–69

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855687e59b0832e9ea6dee71b121301