### PR TITLE
Update Week 13 addition slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ randomized.
 
 Term&nbsp;2 continues math practice with short addition sums. Each day has
 three sessions and the dot counter represents the numbers visually.
+During a session the dots appear across three slides: first the initial
+number, then the second number, and finally the total.
 
 
 An **Addition Module** now appears between Math Dots and the Encyclopedia

--- a/src/modules/AdditionModule.jsx
+++ b/src/modules/AdditionModule.jsx
@@ -1,9 +1,10 @@
+import Carousel from '../components/Carousel'
 import { generateDotPositions } from '../utils/randomDots'
 
 const DotBoard = ({ count }) => {
   const positions = generateDotPositions(count)
   return (
-    <div className="relative inline-block w-16 h-16">
+    <div className="relative w-full h-[60vw] sm:h-[40vh]">
       <span data-testid="dot-count" className="absolute top-0 right-0 m-1 text-[10px] text-black">
         {count}
       </span>
@@ -27,15 +28,13 @@ const DotBoard = ({ count }) => {
 const AdditionModule = ({ sum }) => {
   if (!sum) return null
   const { a, b, sum: result } = sum
+  const slides = [a, b, result]
   return (
     <div className="space-y-4 text-center">
-      <div className="flex items-center justify-center gap-2">
-        <DotBoard count={a} />
-        <span className="text-2xl font-bold">+</span>
-        <DotBoard count={b} />
-        <span className="text-2xl font-bold">=</span>
-        <DotBoard count={result} />
-      </div>
+      <Carousel
+        items={slides}
+        renderItem={(n) => <DotBoard count={n} />}
+      />
       <div className="text-lg font-semibold">{a} + {b} = {result}</div>
     </div>
   )

--- a/src/modules/AdditionModule.test.jsx
+++ b/src/modules/AdditionModule.test.jsx
@@ -2,11 +2,12 @@ import { render, screen } from '@testing-library/react'
 import AdditionModule from './AdditionModule'
 
 describe('AdditionModule', () => {
-  it('renders dots for each part of the sum', () => {
+  it('renders a three slide carousel for the sum', () => {
     const sum = { a: 1, b: 2, sum: 3 }
     render(<AdditionModule sum={sum} />)
-    const counters = screen.getAllByTestId('dot-count')
-    expect(counters).toHaveLength(3)
+    const dots = screen.getAllByTestId('carousel-dot')
+    expect(dots).toHaveLength(3)
+    expect(screen.getByTestId('dot-count')).toHaveTextContent('1')
     expect(screen.getByText('1 + 2 = 3')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- explain that term 2 week 1 addition uses three-slide carousel
- show each sum sequentially using the same math board
- document the behaviour in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556cbc0568832e83da4d2db9f1492a