### PR TITLE
Stop counting after week 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ dots appear on the current slide. Term&nbsp;1 now introduces numbers gradually:
 - **Week&nbsp;9** – numbers 36–40 shuffled, followed by 41–45
 - **Week&nbsp;10** – numbers 41–45 shuffled, followed by 46–50
 
-Weeks&nbsp;11 onward continue sliding the window by five while keeping the lower half
-randomized.
+Counting practice stops here. Starting with Week&nbsp;13, the Math module shows
+only short addition sums.
 
 ### Term 2 Week 1 Addition
 

--- a/public/terms/term2/weeks/week013.json
+++ b/public/terms/term2/weeks/week013.json
@@ -7,6 +7,7 @@
     "goud"
   ],
   "mathWindowStart": 60,
+  "mathWindowLength": 0,
   "encyclopedia": [
     {
       "id": "afghaanse-hond",

--- a/src/components/ThemeList.jsx
+++ b/src/components/ThemeList.jsx
@@ -6,17 +6,21 @@ const ThemeList = () => {
 
   const language = weekData.language[0];
   const mathStart = weekData.mathWindowStart;
-  const mathLength = weekData.mathWindowLength || 10;
+  const mathLength = weekData.mathWindowLength ?? 10;
   const knowledge = weekData.encyclopedia[0].title;
   const firstSum = weekData.addition?.[0]?.[0];
+
+  let mathText = `${mathStart}–${mathStart + mathLength - 1}`;
+  if (mathLength === 0 && firstSum) {
+    mathText = `${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`;
+  } else if (mathLength > 0 && firstSum) {
+    mathText += `, ${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`;
+  }
 
   return (
     <ul className="list-none px-4 md:px-0 space-y-1 text-gray-700">
       <li>📝 Language: {language}…</li>
-      <li>
-        🔢 Math: {mathStart}–{mathStart + mathLength - 1}
-        {firstSum && `, ${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`}
-      </li>
+      <li>🔢 Math: {mathText}</li>
       <li>🦁 Knowledge: {knowledge}…</li>
     </ul>
   );

--- a/src/components/ThemeList.test.jsx
+++ b/src/components/ThemeList.test.jsx
@@ -39,4 +39,20 @@ describe('ThemeList', () => {
     expect(items).toHaveLength(3)
     expect(items[1]).toHaveTextContent('1 + 2 = 3')
   })
+
+  it('shows only the sum when math length is zero', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 60,
+        mathWindowLength: 0,
+        encyclopedia: [{ title: 'Lion' }],
+        addition: [[{ a: 1, b: 2, sum: 3 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('1 + 2 = 3')
+  })
 })


### PR DESCRIPTION
## Summary
- trim week 13 math numbers by setting length to 0
- show only addition sums when no math range
- update documentation about stopping at 50
- test displaying sums without a range

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685572084afc832e92e2befde3cc7f7d