### PR TITLE
Add multiplication practice for Week 27

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,43 @@ kids match each numeral to a tangible count.
 - Session&nbsp;1 – `45 - 23 = 22` (45 dots, minus 23 dots, 22 dots)
 - Session&nbsp;2 – `14 + 9 = 23` (14 dots, 9 dots, 23 dots)
 - Session&nbsp;3 – `38 - 17 = 21` (38 dots, minus 17 dots, 21 dots)
+
+### Term 3 Week 3 Multiplication
+
+**Day&nbsp;1**
+- Session&nbsp;1 – `1 × 2 = 2` (1 dot, 2 dots, 2 dots)
+- Session&nbsp;2 – `6 × 8 = 48` (6 dots, 8 dots, 48 dots)
+- Session&nbsp;3 – `3 × 8 = 24` (3 dots, 8 dots, 24 dots)
+
+**Day&nbsp;2**
+- Session&nbsp;1 – `7 × 4 = 28` (7 dots, 4 dots, 28 dots)
+- Session&nbsp;2 – `9 × 1 = 9` (9 dots, 1 dot, 9 dots)
+- Session&nbsp;3 – `2 × 6 = 12` (2 dots, 6 dots, 12 dots)
+
+**Day&nbsp;3**
+- Session&nbsp;1 – `5 × 7 = 35` (5 dots, 7 dots, 35 dots)
+- Session&nbsp;2 – `4 × 4 = 16` (4 dots, 4 dots, 16 dots)
+- Session&nbsp;3 – `9 × 5 = 45` (9 dots, 5 dots, 45 dots)
+
+**Day&nbsp;4**
+- Session&nbsp;1 – `3 × 2 = 6` (3 dots, 2 dots, 6 dots)
+- Session&nbsp;2 – `5 × 2 = 10` (5 dots, 2 dots, 10 dots)
+- Session&nbsp;3 – `8 × 1 = 8` (8 dots, 1 dot, 8 dots)
+
+**Day&nbsp;5**
+- Session&nbsp;1 – `6 × 7 = 42` (6 dots, 7 dots, 42 dots)
+- Session&nbsp;2 – `12 × 3 = 36` (12 dots, 3 dots, 36 dots)
+- Session&nbsp;3 – `5 × 6 = 30` (5 dots, 6 dots, 30 dots)
+
+**Day&nbsp;6**
+- Session&nbsp;1 – `2 × 9 = 18` (2 dots, 9 dots, 18 dots)
+- Session&nbsp;2 – `5 × 6 = 30` (5 dots, 6 dots, 30 dots)
+- Session&nbsp;3 – `4 × 8 = 32` (4 dots, 8 dots, 32 dots)
+
+**Day&nbsp;7**
+- Session&nbsp;1 – `7 × 2 = 14` (7 dots, 2 dots, 14 dots)
+- Session&nbsp;2 – `9 × 4 = 36` (9 dots, 4 dots, 36 dots)
+- Session&nbsp;3 – `6 × 3 = 18` (6 dots, 3 dots, 18 dots)
 ## Navigation
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.

--- a/public/terms/term3/weeks/week027.json
+++ b/public/terms/term3/weeks/week027.json
@@ -83,5 +83,42 @@
       "fact": "This dog has a ridge of hair along its back.",
       "image": "/images/dog.svg"
     }
+  ],
+  "multiplication": [
+    [
+      { "a": 1, "b": 2, "product": 2 },
+      { "a": 6, "b": 8, "product": 48 },
+      { "a": 3, "b": 8, "product": 24 }
+    ],
+    [
+      { "a": 7, "b": 4, "product": 28 },
+      { "a": 9, "b": 1, "product": 9 },
+      { "a": 2, "b": 6, "product": 12 }
+    ],
+    [
+      { "a": 5, "b": 7, "product": 35 },
+      { "a": 4, "b": 4, "product": 16 },
+      { "a": 9, "b": 5, "product": 45 }
+    ],
+    [
+      { "a": 3, "b": 2, "product": 6 },
+      { "a": 5, "b": 2, "product": 10 },
+      { "a": 8, "b": 1, "product": 8 }
+    ],
+    [
+      { "a": 6, "b": 7, "product": 42 },
+      { "a": 12, "b": 3, "product": 36 },
+      { "a": 5, "b": 6, "product": 30 }
+    ],
+    [
+      { "a": 2, "b": 9, "product": 18 },
+      { "a": 5, "b": 6, "product": 30 },
+      { "a": 4, "b": 8, "product": 32 }
+    ],
+    [
+      { "a": 7, "b": 2, "product": 14 },
+      { "a": 9, "b": 4, "product": 36 },
+      { "a": 6, "b": 3, "product": 18 }
+    ]
   ]
 }

--- a/src/components/ThemeList.jsx
+++ b/src/components/ThemeList.jsx
@@ -10,15 +10,17 @@ const ThemeList = () => {
   const knowledge = weekData.encyclopedia[0].title;
   const firstSum = weekData.addition?.[0]?.[0];
   const firstDiff = weekData.subtraction?.[0]?.[0];
+  const firstProd = weekData.multiplication?.[0]?.[0];
 
   let mathText = `${mathStart}–${mathStart + mathLength - 1}`;
   const sumText = firstSum && `${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`;
   const diffText = firstDiff && `${firstDiff.a} - ${firstDiff.b} = ${firstDiff.difference}`;
+  const prodText = firstProd && `${firstProd.a} × ${firstProd.b} = ${firstProd.product}`;
 
   if (mathLength === 0) {
-    mathText = sumText || diffText || mathText;
-  } else if (sumText || diffText) {
-    mathText += `, ${sumText || diffText}`;
+    mathText = sumText || diffText || prodText || mathText;
+  } else if (sumText || diffText || prodText) {
+    mathText += `, ${sumText || diffText || prodText}`;
   }
 
   return (

--- a/src/components/ThemeList.test.jsx
+++ b/src/components/ThemeList.test.jsx
@@ -56,6 +56,22 @@ describe('ThemeList', () => {
     expect(items[1]).toHaveTextContent('5 - 2 = 3')
   })
 
+  it('includes first multiplication in the math item when provided', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 5,
+        mathWindowLength: 10,
+        encyclopedia: [{ title: 'Lion' }],
+        multiplication: [[{ a: 2, b: 3, product: 6 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('2 × 3 = 6')
+  })
+
   it('shows only the sum when math length is zero', () => {
     useContent.mockReturnValue({
       weekData: {
@@ -86,5 +102,21 @@ describe('ThemeList', () => {
     render(<ThemeList />)
     const items = screen.getAllByRole('listitem')
     expect(items[1]).toHaveTextContent('7 - 4 = 3')
+  })
+
+  it('shows only the product when math length is zero', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 60,
+        mathWindowLength: 0,
+        encyclopedia: [{ title: 'Lion' }],
+        multiplication: [[{ a: 3, b: 2, product: 6 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('3 × 2 = 6')
   })
 })

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -44,11 +44,26 @@ export const createSlides = (
   return [...first, ...secondHalf]
 }
 
-const MathModule = ({ start, length = 10, shuffleFirstHalf, sum, difference }) => {
+const MathModule = ({
+  start,
+  length = 10,
+  shuffleFirstHalf,
+  sum,
+  difference,
+  product,
+}) => {
   const numberSlides = createSlides(start, length, shuffleFirstHalf)
   const additionSlides = sum ? [sum.a, sum.b, sum.sum] : []
-  const subtractionSlides = difference ? [difference.a, difference.b, difference.difference] : []
-  const slides = [...numberSlides, ...additionSlides, ...subtractionSlides]
+  const subtractionSlides = difference
+    ? [difference.a, difference.b, difference.difference]
+    : []
+  const multiplicationSlides = product ? [product.a, product.b, product.product] : []
+  const slides = [
+    ...numberSlides,
+    ...additionSlides,
+    ...subtractionSlides,
+    ...multiplicationSlides,
+  ]
 
   return (
     <div className="space-y-4 text-center">
@@ -64,6 +79,11 @@ const MathModule = ({ start, length = 10, shuffleFirstHalf, sum, difference }) =
       {difference && (
         <div className="text-lg font-semibold">
           {difference.a} - {difference.b} = {difference.difference}
+        </div>
+      )}
+      {product && (
+        <div className="text-lg font-semibold">
+          {product.a} × {product.b} = {product.product}
         </div>
       )}
     </div>

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -24,6 +24,14 @@ describe('MathModule', () => {
     expect(screen.getByText('5 - 2 = 3')).toBeInTheDocument();
   });
 
+  it('appends multiplication slides when a product is provided', () => {
+    const prod = { a: 2, b: 3, product: 6 };
+    render(<MathModule start={1} length={2} product={prod} />);
+    const dots = screen.getAllByTestId('carousel-dot');
+    expect(dots).toHaveLength(5); // 2 number slides + 3 multiplication slides
+    expect(screen.getByText('2 × 3 = 6')).toBeInTheDocument();
+  });
+
   it('renders visible dots for each math slide', () => {
     const { container } = render(<MathModule start={1} />);
     const card = container.querySelector('.card');

--- a/src/screens/NavigationFlow.test.jsx
+++ b/src/screens/NavigationFlow.test.jsx
@@ -12,6 +12,7 @@ describe('Session navigation flow', () => {
     mathWindowStart: 1,
     encyclopedia: [{ image: 'a.jpg', title: 'A', fact: 'fact' }],
     addition: [[{ a: 1, b: 1, sum: 2 }]],
+    multiplication: [[{ a: 2, b: 3, product: 6 }]],
   };
 
   it('advances through modules and completes session', () => {

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -67,6 +67,9 @@ const Session = () => {
           difference={
             weekData.subtraction?.[progress.day - 1]?.[progress.session - 1]
           }
+          product={
+            weekData.multiplication?.[progress.day - 1]?.[progress.session - 1]
+          }
         />
       )}
       {step === titles.indexOf('🦁 Encyclopedia') && (


### PR DESCRIPTION
## Summary
- support multiplication problems in `MathModule`
- show multiplication preview text in `ThemeList`
- update `Session` and tests for multiplication
- create Term 3 Week 3 multiplication data
- document new week content in README

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855ca056c54832e8382ce86b3e64b02