### PR TITLE
Remove counting slides for week 27

### DIFF
--- a/public/terms/term3/weeks/week027.json
+++ b/public/terms/term3/weeks/week027.json
@@ -12,6 +12,7 @@
     "sleutel"
   ],
   "mathWindowStart": 131,
+  "mathWindowLength": 0,
   "encyclopedia": [
     {
       "id": "afghaanse-hond",


### PR DESCRIPTION
## Summary
- stop showing counting numbers for week 27 multiplication lessons

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855cc35d0cc832e9a96e071be6ee5e9