### PR TITLE
Enable division slides

### DIFF
--- a/public/terms/term3/weeks/week029.json
+++ b/public/terms/term3/weeks/week029.json
@@ -12,6 +12,7 @@
     "bak"
   ],
   "mathWindowStart": 141,
+  "mathWindowLength": 0,
   "encyclopedia": [
     {
       "id": "afghaanse-hond",

--- a/src/components/ThemeList.jsx
+++ b/src/components/ThemeList.jsx
@@ -11,16 +11,18 @@ const ThemeList = () => {
   const firstSum = weekData.addition?.[0]?.[0];
   const firstDiff = weekData.subtraction?.[0]?.[0];
   const firstProd = weekData.multiplication?.[0]?.[0];
+  const firstQuot = weekData.division?.[0]?.[0];
 
   let mathText = `${mathStart}–${mathStart + mathLength - 1}`;
   const sumText = firstSum && `${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`;
   const diffText = firstDiff && `${firstDiff.a} - ${firstDiff.b} = ${firstDiff.difference}`;
   const prodText = firstProd && `${firstProd.a} × ${firstProd.b} = ${firstProd.product}`;
+  const quotText = firstQuot && `${firstQuot.a} ÷ ${firstQuot.b} = ${firstQuot.quotient}`;
 
   if (mathLength === 0) {
-    mathText = sumText || diffText || prodText || mathText;
-  } else if (sumText || diffText || prodText) {
-    mathText += `, ${sumText || diffText || prodText}`;
+    mathText = sumText || diffText || prodText || quotText || mathText;
+  } else if (sumText || diffText || prodText || quotText) {
+    mathText += `, ${sumText || diffText || prodText || quotText}`;
   }
 
   return (

--- a/src/components/ThemeList.test.jsx
+++ b/src/components/ThemeList.test.jsx
@@ -72,6 +72,22 @@ describe('ThemeList', () => {
     expect(items[1]).toHaveTextContent('2 × 3 = 6')
   })
 
+  it('includes first division in the math item when provided', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 5,
+        mathWindowLength: 10,
+        encyclopedia: [{ title: 'Lion' }],
+        division: [[{ a: 8, b: 2, quotient: 4 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('8 ÷ 2 = 4')
+  })
+
   it('shows only the sum when math length is zero', () => {
     useContent.mockReturnValue({
       weekData: {
@@ -118,5 +134,21 @@ describe('ThemeList', () => {
     render(<ThemeList />)
     const items = screen.getAllByRole('listitem')
     expect(items[1]).toHaveTextContent('3 × 2 = 6')
+  })
+
+  it('shows only the quotient when math length is zero', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 60,
+        mathWindowLength: 0,
+        encyclopedia: [{ title: 'Lion' }],
+        division: [[{ a: 9, b: 3, quotient: 3 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('9 ÷ 3 = 3')
   })
 })

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -51,6 +51,7 @@ const MathModule = ({
   sum,
   difference,
   product,
+  quotient,
 }) => {
   const numberSlides = createSlides(start, length, shuffleFirstHalf)
   const additionSlides = sum ? [sum.a, sum.b, sum.sum] : []
@@ -58,11 +59,13 @@ const MathModule = ({
     ? [difference.a, difference.b, difference.difference]
     : []
   const multiplicationSlides = product ? [product.a, product.b, product.product] : []
+  const divisionSlides = quotient ? [quotient.a, quotient.b, quotient.quotient] : []
   const slides = [
     ...numberSlides,
     ...additionSlides,
     ...subtractionSlides,
     ...multiplicationSlides,
+    ...divisionSlides,
   ]
 
   return (
@@ -84,6 +87,11 @@ const MathModule = ({
       {product && (
         <div className="text-lg font-semibold">
           {product.a} × {product.b} = {product.product}
+        </div>
+      )}
+      {quotient && (
+        <div className="text-lg font-semibold">
+          {quotient.a} ÷ {quotient.b} = {quotient.quotient}
         </div>
       )}
     </div>

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -32,6 +32,14 @@ describe('MathModule', () => {
     expect(screen.getByText('2 × 3 = 6')).toBeInTheDocument();
   });
 
+  it('appends division slides when a quotient is provided', () => {
+    const quot = { a: 8, b: 2, quotient: 4 };
+    render(<MathModule start={1} length={2} quotient={quot} />);
+    const dots = screen.getAllByTestId('carousel-dot');
+    expect(dots).toHaveLength(5); // 2 number slides + 3 division slides
+    expect(screen.getByText('8 ÷ 2 = 4')).toBeInTheDocument();
+  });
+
   it('renders visible dots for each math slide', () => {
     const { container } = render(<MathModule start={1} />);
     const card = container.querySelector('.card');

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -70,6 +70,9 @@ const Session = () => {
           product={
             weekData.multiplication?.[progress.day - 1]?.[progress.session - 1]
           }
+          quotient={
+            weekData.division?.[progress.day - 1]?.[progress.session - 1]
+          }
         />
       )}
       {step === titles.indexOf('🦁 Encyclopedia') && (


### PR DESCRIPTION
## Summary
- support division slides in MathModule and ThemeList
- disable counting numbers for week 29
- show division preview text
- pass quotient info to Session
- test division display logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685667e85578832e8491cf93e1112fc8