### PR TITLE
Add counting schedule for Term 2 Week 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,42 +481,23 @@ kids match each numeral to a tangible count.
 - Session&nbsp;2 – `28 - 9 = 19` (28 dots, minus 9 dots, 19 dots)
 - Session&nbsp;3 – `43 - 2 = 41` (43 dots, minus 2 dots, 41 dots)
 
-### Term 2 Week 10 Subtraction
+### Term 2 Week 10 Counting in 2’s and 3’s
 
-**Day&nbsp;1**
-- Session&nbsp;1 – `44 - 17 = 27` (44 dots, minus 17 dots, 27 dots)
-- Session&nbsp;2 – `33 - 12 = 21` (33 dots, minus 12 dots, 21 dots)
-- Session&nbsp;3 – `43 - 2 = 41` (43 dots, minus 2 dots, 41 dots)
+Tel vinnig met behulp van flitskaarte.
 
-**Day&nbsp;2**
-- Session&nbsp;1 – `28 - 15 = 13` (28 dots, minus 15 dots, 13 dots)
-- Session&nbsp;2 – `16 - 8 = 8` (16 dots, minus 8 dots, 8 dots)
-- Session&nbsp;3 – `27 - 3 = 24` (27 dots, minus 3 dots, 24 dots)
+**Day&nbsp;1** – tel in twee’s: 2, 4, 6, 8, 10
 
-**Day&nbsp;3**
-- Session&nbsp;1 – `50 - 25 = 25` (50 dots, minus 25 dots, 25 dots)
-- Session&nbsp;2 – `38 - 19 = 19` (38 dots, minus 19 dots, 19 dots)
-- Session&nbsp;3 – `36 - 6 = 30` (36 dots, minus 6 dots, 30 dots)
+**Day&nbsp;2** – tel in twee’s: 12, 14, 16, 18, 20
 
-**Day&nbsp;4**
-- Session&nbsp;1 – `40 - 18 = 22` (40 dots, minus 18 dots, 22 dots)
-- Session&nbsp;2 – `29 - 11 = 18` (29 dots, minus 11 dots, 18 dots)
-- Session&nbsp;3 – `35 - 5 = 30` (35 dots, minus 5 dots, 30 dots)
+**Day&nbsp;3** – tel in drie’s: 3, 6, 9, 12, 15
 
-**Day&nbsp;5**
-- Session&nbsp;1 – `47 - 23 = 24` (47 dots, minus 23 dots, 24 dots)
-- Session&nbsp;2 – `31 - 14 = 17` (31 dots, minus 14 dots, 17 dots)
-- Session&nbsp;3 – `26 - 4 = 22` (26 dots, minus 4 dots, 22 dots)
+**Day&nbsp;4** – tel in drie’s: 15, 18, 21, 24, 27, 30
 
-**Day&nbsp;6**
-- Session&nbsp;1 – `24 - 7 = 17` (24 dots, minus 7 dots, 17 dots)
-- Session&nbsp;2 – `19 - 9 = 10` (19 dots, minus 9 dots, 10 dots)
-- Session&nbsp;3 – `37 - 18 = 19` (37 dots, minus 18 dots, 19 dots)
+**Day&nbsp;5** – tel in drie’s: 30, 33, 36, 39, 42, 45, 48
 
-**Day&nbsp;7**
-- Session&nbsp;1 – `30 - 12 = 18` (30 dots, minus 12 dots, 18 dots)
-- Session&nbsp;2 – `28 - 13 = 15` (28 dots, minus 13 dots, 15 dots)
-- Session&nbsp;3 – `22 - 6 = 16` (22 dots, minus 6 dots, 16 dots)
+**Day&nbsp;6** – tel in twee’s: 50, 52, 54, 56, 58, 60
+
+**Day&nbsp;7** – tel in drie’s: 51, 54, 57, 60, 63, 66, 69
 
 ### Term 3 Week 1 Addition & Subtraction
 

--- a/public/terms/term2/weeks/week022.json
+++ b/public/terms/term2/weeks/week022.json
@@ -85,41 +85,13 @@
       "image": "/images/dog.svg"
     }
   ],
-  "subtraction": [
-    [
-      { "a": 44, "b": 17, "difference": 27 },
-      { "a": 33, "b": 12, "difference": 21 },
-      { "a": 43, "b": 2, "difference": 41 }
-    ],
-    [
-      { "a": 28, "b": 15, "difference": 13 },
-      { "a": 16, "b": 8, "difference": 8 },
-      { "a": 27, "b": 3, "difference": 24 }
-    ],
-    [
-      { "a": 50, "b": 25, "difference": 25 },
-      { "a": 38, "b": 19, "difference": 19 },
-      { "a": 36, "b": 6, "difference": 30 }
-    ],
-    [
-      { "a": 40, "b": 18, "difference": 22 },
-      { "a": 29, "b": 11, "difference": 18 },
-      { "a": 35, "b": 5, "difference": 30 }
-    ],
-    [
-      { "a": 47, "b": 23, "difference": 24 },
-      { "a": 31, "b": 14, "difference": 17 },
-      { "a": 26, "b": 4, "difference": 22 }
-    ],
-    [
-      { "a": 24, "b": 7, "difference": 17 },
-      { "a": 19, "b": 9, "difference": 10 },
-      { "a": 37, "b": 18, "difference": 19 }
-    ],
-    [
-      { "a": 30, "b": 12, "difference": 18 },
-      { "a": 28, "b": 13, "difference": 15 },
-      { "a": 22, "b": 6, "difference": 16 }
-    ]
+  "counting": [
+    [2, 4, 6, 8, 10],
+    [12, 14, 16, 18, 20],
+    [3, 6, 9, 12, 15],
+    [15, 18, 21, 24, 27, 30],
+    [30, 33, 36, 39, 42, 45, 48],
+    [50, 52, 54, 56, 58, 60],
+    [51, 54, 57, 60, 63, 66, 69]
   ]
 }

--- a/src/components/ThemeList.jsx
+++ b/src/components/ThemeList.jsx
@@ -12,6 +12,7 @@ const ThemeList = () => {
   const firstDiff = weekData.subtraction?.[0]?.[0];
   const firstProd = weekData.multiplication?.[0]?.[0];
   const firstQuot = weekData.division?.[0]?.[0];
+  const firstCount = weekData.counting?.[0];
 
   let mathText = `${mathStart}–${mathStart + mathLength - 1}`;
   const sumText = firstSum && `${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`;
@@ -19,7 +20,9 @@ const ThemeList = () => {
   const prodText = firstProd && `${firstProd.a} × ${firstProd.b} = ${firstProd.product}`;
   const quotText = firstQuot && `${firstQuot.a} ÷ ${firstQuot.b} = ${firstQuot.quotient}`;
 
-  if (mathLength === 0) {
+  if (firstCount) {
+    mathText = firstCount.join(', ');
+  } else if (mathLength === 0) {
     mathText = sumText || diffText || prodText || quotText || mathText;
   } else if (sumText || diffText || prodText || quotText) {
     mathText += `, ${sumText || diffText || prodText || quotText}`;

--- a/src/components/ThemeList.test.jsx
+++ b/src/components/ThemeList.test.jsx
@@ -151,4 +151,20 @@ describe('ThemeList', () => {
     const items = screen.getAllByRole('listitem')
     expect(items[1]).toHaveTextContent('9 ÷ 3 = 3')
   })
+
+  it('shows counting numbers when provided', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 60,
+        mathWindowLength: 5,
+        encyclopedia: [{ title: 'Lion' }],
+        counting: [[2, 4, 6, 8, 10]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('2, 4, 6, 8, 10')
+  })
 })

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -35,11 +35,15 @@ export const createSlides = (
   start,
   length = 10,
   shuffleFirstHalf = start !== 1,
+  numbers,
 ) => {
-  const numbers = Array.from({ length }, (_, i) => start + i)
-  const firstHalfCount = Math.min(5, numbers.length)
-  const firstHalf = numbers.slice(0, firstHalfCount)
-  const secondHalf = numbers.slice(firstHalfCount)
+  if (Array.isArray(numbers)) {
+    return numbers
+  }
+  const seq = Array.from({ length }, (_, i) => start + i)
+  const firstHalfCount = Math.min(5, seq.length)
+  const firstHalf = seq.slice(0, firstHalfCount)
+  const secondHalf = seq.slice(firstHalfCount)
   const first = shuffleFirstHalf ? shuffle(firstHalf) : firstHalf
   return [...first, ...secondHalf]
 }
@@ -48,12 +52,13 @@ const MathModule = ({
   start,
   length = 10,
   shuffleFirstHalf,
+  numbers,
   sum,
   difference,
   product,
   quotient,
 }) => {
-  const numberSlides = createSlides(start, length, shuffleFirstHalf)
+  const numberSlides = createSlides(start, length, shuffleFirstHalf, numbers)
   const additionSlides = sum ? [sum.a, sum.b, sum.sum] : []
   const subtractionSlides = difference
     ? [difference.a, difference.b, difference.difference]

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -91,5 +91,10 @@ describe('MathModule', () => {
       const firstHalf = [...slides.slice(0, 5)].sort((a, b) => a - b);
       expect(firstHalf).toEqual([6, 7, 8, 9, 10]);
     });
+
+    it('uses explicit numbers when provided', () => {
+      const slides = createSlides(1, 5, false, [2, 4, 6]);
+      expect(slides).toEqual([2, 4, 6]);
+    });
   });
 });

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -61,6 +61,7 @@ const Session = () => {
           start={weekData.mathWindowStart}
           length={weekData.mathWindowLength}
           shuffleFirstHalf={weekData.mathShuffleFirstHalf}
+          numbers={weekData.counting?.[progress.day - 1]}
           sum={
             weekData.addition?.[progress.day - 1]?.[progress.session - 1]
           }


### PR DESCRIPTION
## Summary
- switch Term 2 week 10 from subtraction to skip counting
- support explicit number lists in MathModule
- display counting numbers in ThemeList
- update week 10 data with counting sequences
- test ThemeList and MathModule counting logic

## Testing
- `npx jest tests` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68567d162738832e8d4833aadbddd4e2