### PR TITLE
Fix triple-number math display

### DIFF
--- a/src/components/ThemeList.jsx
+++ b/src/components/ThemeList.jsx
@@ -15,8 +15,12 @@ const ThemeList = () => {
   const firstCount = weekData.counting?.[0];
 
   let mathText = `${mathStart}–${mathStart + mathLength - 1}`;
-  const sumText = firstSum && `${firstSum.a} + ${firstSum.b} = ${firstSum.sum}`;
-  const diffText = firstDiff && `${firstDiff.a} - ${firstDiff.b} = ${firstDiff.difference}`;
+  const sumText =
+    firstSum &&
+    `${firstSum.a} + ${firstSum.b}${firstSum.c !== undefined ? ` + ${firstSum.c}` : ''} = ${firstSum.sum}`;
+  const diffText =
+    firstDiff &&
+    `${firstDiff.a} - ${firstDiff.b}${firstDiff.c !== undefined ? ` - ${firstDiff.c}` : ''} = ${firstDiff.difference}`;
   const prodText = firstProd && `${firstProd.a} × ${firstProd.b} = ${firstProd.product}`;
   const quotText = firstQuot && `${firstQuot.a} ÷ ${firstQuot.b} = ${firstQuot.quotient}`;
 

--- a/src/components/ThemeList.test.jsx
+++ b/src/components/ThemeList.test.jsx
@@ -40,6 +40,22 @@ describe('ThemeList', () => {
     expect(items[1]).toHaveTextContent('1 + 2 = 3')
   })
 
+  it('handles three-number addition in the math item', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 5,
+        mathWindowLength: 10,
+        encyclopedia: [{ title: 'Lion' }],
+        addition: [[{ a: 1, b: 2, c: 3, sum: 6 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('1 + 2 + 3 = 6')
+  })
+
   it('includes first subtraction in the math item when provided', () => {
     useContent.mockReturnValue({
       weekData: {
@@ -54,6 +70,22 @@ describe('ThemeList', () => {
     render(<ThemeList />)
     const items = screen.getAllByRole('listitem')
     expect(items[1]).toHaveTextContent('5 - 2 = 3')
+  })
+
+  it('handles three-number subtraction in the math item', () => {
+    useContent.mockReturnValue({
+      weekData: {
+        language: ['apple'],
+        mathWindowStart: 5,
+        mathWindowLength: 10,
+        encyclopedia: [{ title: 'Lion' }],
+        subtraction: [[{ a: 7, b: 3, c: 1, difference: 3 }]],
+      },
+    })
+
+    render(<ThemeList />)
+    const items = screen.getAllByRole('listitem')
+    expect(items[1]).toHaveTextContent('7 - 3 - 1 = 3')
   })
 
   it('includes first multiplication in the math item when provided', () => {

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -59,9 +59,16 @@ const MathModule = ({
   quotient,
 }) => {
   const numberSlides = createSlides(start, length, shuffleFirstHalf, numbers)
-  const additionSlides = sum ? [sum.a, sum.b, sum.sum] : []
+  const additionSlides = sum
+    ? [sum.a, sum.b, ...(sum.c !== undefined ? [sum.c] : []), sum.sum]
+    : []
   const subtractionSlides = difference
-    ? [difference.a, difference.b, difference.difference]
+    ? [
+        difference.a,
+        difference.b,
+        ...(difference.c !== undefined ? [difference.c] : []),
+        difference.difference,
+      ]
     : []
   const multiplicationSlides = product ? [product.a, product.b, product.product] : []
   const divisionSlides = quotient ? [quotient.a, quotient.b, quotient.quotient] : []
@@ -81,12 +88,15 @@ const MathModule = ({
       />
       {sum && (
         <div className="text-lg font-semibold">
-          {sum.a} + {sum.b} = {sum.sum}
+          {sum.a} + {sum.b}
+          {sum.c !== undefined ? ` + ${sum.c}` : ''} = {sum.sum}
         </div>
       )}
       {difference && (
         <div className="text-lg font-semibold">
-          {difference.a} - {difference.b} = {difference.difference}
+          {difference.a} - {difference.b}
+          {difference.c !== undefined ? ` - ${difference.c}` : ''} ={' '}
+          {difference.difference}
         </div>
       )}
       {product && (

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -16,12 +16,28 @@ describe('MathModule', () => {
     expect(screen.getByText('1 + 2 = 3')).toBeInTheDocument();
   });
 
+  it('supports three-number addition problems', () => {
+    const sum = { a: 1, b: 2, c: 3, sum: 6 };
+    render(<MathModule start={1} length={2} sum={sum} />);
+    const dots = screen.getAllByTestId('carousel-dot');
+    expect(dots).toHaveLength(6); // 2 number slides + 4 addition slides
+    expect(screen.getByText('1 + 2 + 3 = 6')).toBeInTheDocument();
+  });
+
   it('appends subtraction slides when a difference is provided', () => {
     const diff = { a: 5, b: 2, difference: 3 };
     render(<MathModule start={1} length={2} difference={diff} />);
     const dots = screen.getAllByTestId('carousel-dot');
     expect(dots).toHaveLength(5); // 2 number slides + 3 subtraction slides
     expect(screen.getByText('5 - 2 = 3')).toBeInTheDocument();
+  });
+
+  it('supports three-number subtraction problems', () => {
+    const diff = { a: 7, b: 3, c: 1, difference: 3 };
+    render(<MathModule start={1} length={2} difference={diff} />);
+    const dots = screen.getAllByTestId('carousel-dot');
+    expect(dots).toHaveLength(6); // 2 number slides + 4 subtraction slides
+    expect(screen.getByText('7 - 3 - 1 = 3')).toBeInTheDocument();
   });
 
   it('appends multiplication slides when a product is provided', () => {


### PR DESCRIPTION
## Summary
- handle addition and subtraction with three numbers
- update theme text for triple-number operations
- test MathModule and ThemeList with triple-number sums/differences

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d0982708832e8cddaac9a1fde9c7