### PR TITLE
Fix Week 44 data

### DIFF
--- a/public/terms/term4/weeks/week044.json
+++ b/public/terms/term4/weeks/week044.json
@@ -12,6 +12,7 @@
     "katmandjie"
   ],
   "mathWindowStart": 216,
+  "mathWindowLength": 0,
   "encyclopedia": [
     {
       "id": "afghaanse-hond",


### PR DESCRIPTION
## Summary
- disable default counting slides for Term 4 Week 8 (week 44)

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6857fc796cc8832eb16b4994f4c1862c