### PR TITLE
Fix week routing for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ the browser console.
 Weeks are grouped into four terms. Term 1 and Term 2 contain ten weeks each,
 Term 3 has twelve weeks, and Term 4 has eleven weeks. The helper
 `getTermForWeek` in `src/utils/termHelpers.js` converts a week number to its
-term, using the `WEEKS_PER_TERM` constant.
+term based on these fixed ranges.
 
 ## Progress Storage
 

--- a/src/utils/termHelpers.js
+++ b/src/utils/termHelpers.js
@@ -1,9 +1,10 @@
-export const WEEKS_PER_TERM = 12;
-export const TOTAL_TERMS = 4;
-
+// Term 1 now contains only weeks 1–10 after removing weeks 11 and 12.
+// Term 2 covers weeks 11–20, Term 3 spans weeks 25–36 and the remaining
+// weeks 37–47 belong to Term 4. Weeks 21–24 currently have no content but
+// map to Term 3 for consistency.
 export function getTermForWeek(week) {
-  if (week < 1) {
-    return 1;
-  }
-  return Math.ceil(week / WEEKS_PER_TERM);
+  if (week <= 10) return 1;
+  if (week <= 20) return 2;
+  if (week <= 36) return 3;
+  return 4;
 }

--- a/tests/termHelpers.test.js
+++ b/tests/termHelpers.test.js
@@ -3,13 +3,13 @@ import { getTermForWeek } from '../src/utils/termHelpers.js';
 describe('getTermForWeek', () => {
   test.each([
     [1, 1],
-    [12, 1],
-    [13, 2],
-    [24, 2],
-    [25, 3],
+    [10, 1],
+    [11, 2],
+    [20, 2],
+    [21, 3],
     [36, 3],
     [37, 4],
-    [46, 4],
+    [47, 4],
   ])('week %i is in term %i', (week, term) => {
     expect(getTermForWeek(week)).toBe(term);
   });


### PR DESCRIPTION
## Summary
- map weeks to the correct term after removing weeks 11–12 from term 1
- update README to describe fixed week ranges
- adjust tests for new `getTermForWeek` logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68592ef28db8832ebdd4f85d13384f51