### PR TITLE
Add counting captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ is absolutely positioned in the slide's top-right corner (about 10&nbsp;px) so
 it never shifts when the dot board is centered. The count indicates how many
 dots appear on the current slide. Term&nbsp;1 now introduces numbers gradually:
 
+When only counting numbers are shown, a caption beneath the carousel now
+summarizes the sequence (e.g. "Count in 2's from 2 to 20"). This mirrors the
+addition and subtraction captions used in later weeks.
+
 - **Week&nbsp;1** – numbers 1–5 in order
 - **Week&nbsp;2** – numbers 1–5 shuffled, followed by 6–10
 - **Week&nbsp;3** – numbers 6–10 shuffled, followed by 11–15

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -80,12 +80,33 @@ const MathModule = ({
     ...divisionSlides,
   ]
 
+  const showCountingText =
+    !sum && !difference && !product && !quotient && slides.length > 0
+
+  let countingText = ''
+  if (showCountingText) {
+    const seq = Array.isArray(numbers)
+      ? numbers
+      : Array.from({ length }, (_, i) => start + i)
+    const step = seq.length > 1 ? seq[1] - seq[0] : 1
+    const absStep = Math.abs(step)
+    const min = Math.min(...seq)
+    const max = Math.max(...seq)
+    countingText =
+      absStep === 1
+        ? `Count from ${min} to ${max}`
+        : `Count in ${absStep}'s from ${min} to ${max}`
+  }
+
   return (
     <div className="space-y-4 text-center">
       <Carousel
         items={slides}
         renderItem={(n) => <DotBoard count={n} />}
       />
+      {showCountingText && (
+        <div className="text-lg font-semibold">{countingText}</div>
+      )}
       {sum && (
         <div className="text-lg font-semibold">
           {sum.a} + {sum.b}

--- a/src/modules/MathModule.test.jsx
+++ b/src/modules/MathModule.test.jsx
@@ -96,6 +96,16 @@ describe('MathModule', () => {
     expect(board.contains(counter)).toBe(false);
   });
 
+  it('shows counting text for sequential numbers', () => {
+    render(<MathModule start={1} length={3} />);
+    expect(screen.getByText('Count from 1 to 3')).toBeInTheDocument();
+  });
+
+  it("shows counting text for custom step sequences", () => {
+    render(<MathModule numbers={[2, 4, 6, 8]} />);
+    expect(screen.getByText("Count in 2's from 2 to 8")).toBeInTheDocument();
+  });
+
   describe('createSlides', () => {
     it('returns week one numbers in order', () => {
       expect(createSlides(1, 5, false)).toEqual([1, 2, 3, 4, 5]);


### PR DESCRIPTION
## Summary
- display a caption for counting sequences in MathModule
- test counting captions
- document the new counting caption feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68593c42cb5c832eb2633d75c0d2273f