### PR TITLE
Remove duplicate session headings

### DIFF
--- a/src/screens/NavigationFlow.test.jsx
+++ b/src/screens/NavigationFlow.test.jsx
@@ -34,11 +34,11 @@ describe('Session navigation flow', () => {
     );
 
     // Starts at Language step
-    expect(screen.getByText('📝 Language')).toBeInTheDocument();
+    expect(screen.getByText('one')).toBeInTheDocument();
     fireEvent.click(screen.getAllByRole('button', { name: /next/i })[1]);
-    expect(screen.getByText('🔢 Math')).toBeInTheDocument();
+    expect(screen.getByTestId('dot-count')).toBeInTheDocument();
     fireEvent.click(screen.getAllByRole('button', { name: /next/i })[1]);
-    expect(screen.getByText('🦁 Encyclopedia')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'A' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /finish session/i }));
     expect(completeSession).toHaveBeenCalled();
     expect(screen.getByText(/great job/i)).toBeInTheDocument();

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -52,8 +52,6 @@ const Session = () => {
     <>
       <Header />
       <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20">
-        <h1 className="text-2xl font-bold">Week {progress.week} – Session</h1>
-      <h2 className="text-lg text-gray-500">{titles[step]}</h2>
 
       {step === 0 && <LanguageModule words={weekData.language} />}
       {step === titles.indexOf('🔢 Math') && (


### PR DESCRIPTION
## Summary
- remove duplicate headings from the Session screen
- update navigation flow test to check module content instead of headings

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685942cbf068832e9dbd19146ecf953b