### PR TITLE
Fix header overflow

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,11 +4,18 @@ import { useContent } from '../contexts/ContentProvider'
 const Header = () => {
   const { progress } = useContent()
   return (
-    <header className="fixed top-0 left-0 w-full bg-white shadow p-4 flex items-center justify-between z-50" data-testid="app-header">
-      <Link to="/" aria-label="Home" className="text-2xl">🏠</Link>
-      <span className="text-sm font-semibold">
-        Week {progress.week} • Day {progress.day} • Session {progress.session}
-      </span>
+    <header
+      className="fixed top-0 left-0 w-full bg-white shadow p-4 z-50"
+      data-testid="app-header"
+    >
+      <div className="max-w-md mx-auto flex items-center justify-between">
+        <Link to="/" aria-label="Home" className="text-2xl">
+          🏠
+        </Link>
+        <span className="text-sm font-semibold">
+          Week {progress.week} • Day {progress.day} • Session {progress.session}
+        </span>
+      </div>
     </header>
   )
 }


### PR DESCRIPTION
## Summary
- constrain header contents to the width of the main container

## Testing
- `npx jest tests --runInBand --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685945d9efe4832eb598283e606333ce