### PR TITLE
Change font to Comic Sans

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ properties (e.g. `width: 2.5rem; height: 2.5rem;`) or use the new `size-*`
 utilities.
 
 You can modify default styles by editing `tailwind.config.cjs`. Add new colors
-or font families under the `extend` section. Reusable custom classes should be
+or font families under the `extend` section. The application now sets all text
+to **Comic Sans** via the `fontFamily.sans` configuration. Reusable custom
+classes should be
 placed inside the `@layer components` block in `src/index.css`.
 
 Lint the code with ESLint:

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    font-family: 'Comic Sans MS', 'Comic Sans', cursive;
+  }
+}
+
 @layer components {
   .btn {
     padding: 0.5rem 1.25rem;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,3 +1,5 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
 module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx,css}'],
   theme: {
@@ -7,6 +9,9 @@ module.exports = {
           DEFAULT: '#4f46e5',
           dark: '#4338ca',
         },
+      },
+      fontFamily: {
+        sans: ['"Comic Sans MS"', '"Comic Sans"', 'cursive', ...defaultTheme.fontFamily.sans],
       },
     },
   },


### PR DESCRIPTION
## Summary
- configure Tailwind to use Comic Sans as the default sans font
- apply Comic Sans in base CSS layer
- document Comic Sans setup in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68594c534cec832e9a624d5994d3af90