### PR TITLE
Set Comic Sans across SVG placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ or font families under the `extend` section. The application now sets all text
 to **Comic Sans** via the `fontFamily.sans` configuration. Reusable custom
 classes should be
 placed inside the `@layer components` block in `src/index.css`.
+Placeholder SVG images now embed `font-family="Comic Sans MS, Comic Sans,
+cursive"` so any fallback text also displays in Comic Sans.
 
 Lint the code with ESLint:
 

--- a/public/images/bear.svg
+++ b/public/images/bear.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bear</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bear</text>
 </svg>

--- a/public/images/cat.svg
+++ b/public/images/cat.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Cat</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Cat</text>
 </svg>

--- a/public/images/dog.svg
+++ b/public/images/dog.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dog</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dog</text>
 </svg>

--- a/public/images/elephant.svg
+++ b/public/images/elephant.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Elephant</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Elephant</text>
 </svg>

--- a/public/images/giraffe.svg
+++ b/public/images/giraffe.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Giraffe</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Giraffe</text>
 </svg>

--- a/public/images/kangaroo.svg
+++ b/public/images/kangaroo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Kangaroo</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Kangaroo</text>
 </svg>

--- a/public/images/koala.svg
+++ b/public/images/koala.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Koala</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Koala</text>
 </svg>

--- a/public/images/lion.svg
+++ b/public/images/lion.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Lion</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Lion</text>
 </svg>

--- a/public/images/monkey.svg
+++ b/public/images/monkey.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Monkey</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Monkey</text>
 </svg>

--- a/public/images/panda.svg
+++ b/public/images/panda.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Panda</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Panda</text>
 </svg>

--- a/public/images/tiger.svg
+++ b/public/images/tiger.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Tiger</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Tiger</text>
 </svg>

--- a/public/images/zebra.svg
+++ b/public/images/zebra.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Zebra</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Zebra</text>
 </svg>

--- a/src/assets/encyclopedia/abbesinier-kat.svg
+++ b/src/assets/encyclopedia/abbesinier-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Abbesiniér kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Abbesiniér kat</text></svg>

--- a/src/assets/encyclopedia/afghaanse-hond.svg
+++ b/src/assets/encyclopedia/afghaanse-hond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Afgaanse hond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Afgaanse hond</text></svg>

--- a/src/assets/encyclopedia/bloedhond.svg
+++ b/src/assets/encyclopedia/bloedhond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bloedhond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bloedhond</text></svg>

--- a/src/assets/encyclopedia/bulhond.svg
+++ b/src/assets/encyclopedia/bulhond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bulhond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Bulhond</text></svg>

--- a/src/assets/encyclopedia/chinchilla-kat.svg
+++ b/src/assets/encyclopedia/chinchilla-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Chinchilla kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Chinchilla kat</text></svg>

--- a/src/assets/encyclopedia/dalmatiese-hond.svg
+++ b/src/assets/encyclopedia/dalmatiese-hond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dalmatiese hond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dalmatiese hond</text></svg>

--- a/src/assets/encyclopedia/dashond.svg
+++ b/src/assets/encyclopedia/dashond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dashond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Dashond</text></svg>

--- a/src/assets/encyclopedia/engelse-patryshond.svg
+++ b/src/assets/encyclopedia/engelse-patryshond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Engelse Patryshond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Engelse Patryshond</text></svg>

--- a/src/assets/encyclopedia/franse-dashond.svg
+++ b/src/assets/encyclopedia/franse-dashond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Franse Dashond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Franse Dashond</text></svg>

--- a/src/assets/encyclopedia/goudkleurige-apporteerhond.svg
+++ b/src/assets/encyclopedia/goudkleurige-apporteerhond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Goudkleurige Apporteerhond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Goudkleurige Apporteerhond</text></svg>

--- a/src/assets/encyclopedia/jagwindhond.svg
+++ b/src/assets/encyclopedia/jagwindhond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Jagwindhond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Jagwindhond</text></svg>

--- a/src/assets/encyclopedia/lion.svg
+++ b/src/assets/encyclopedia/lion.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
   <rect width="100%" height="100%" fill="#ddd"/>
-  <text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Lion</text>
+  <text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Lion</text>
 </svg>

--- a/src/assets/encyclopedia/maine-coon.svg
+++ b/src/assets/encyclopedia/maine-coon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Maine Coon</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Maine Coon</text></svg>

--- a/src/assets/encyclopedia/ragdoll-kat.svg
+++ b/src/assets/encyclopedia/ragdoll-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Ragdoll kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Ragdoll kat</text></svg>

--- a/src/assets/encyclopedia/rhodesiese-rifrughond.svg
+++ b/src/assets/encyclopedia/rhodesiese-rifrughond.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rhodesiese Rifrughond</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rhodesiese Rifrughond</text></svg>

--- a/src/assets/encyclopedia/rob-bruin-himalajan-kat.svg
+++ b/src/assets/encyclopedia/rob-bruin-himalajan-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rob bruin Himalajan kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rob bruin Himalajan kat</text></svg>

--- a/src/assets/encyclopedia/rokerige-swart-persiese-kat.svg
+++ b/src/assets/encyclopedia/rokerige-swart-persiese-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rokerige Swart Persiese kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rokerige Swart Persiese kat</text></svg>

--- a/src/assets/encyclopedia/rooi-persiese-kat.svg
+++ b/src/assets/encyclopedia/rooi-persiese-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rooi Persiese kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Rooi Persiese kat</text></svg>

--- a/src/assets/encyclopedia/siamese-kat.svg
+++ b/src/assets/encyclopedia/siamese-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Siamese kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Siamese kat</text></svg>

--- a/src/assets/encyclopedia/turkse-angora-kat.svg
+++ b/src/assets/encyclopedia/turkse-angora-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Turkse Angora kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Turkse Angora kat</text></svg>

--- a/src/assets/encyclopedia/turkse-van-kat.svg
+++ b/src/assets/encyclopedia/turkse-van-kat.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Turkse Van kat</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200"><rect width="100%" height="100%" fill="#ddd"/><text font-family="Comic Sans MS, Comic Sans, cursive" x="50%" y="50%" text-anchor="middle" fill="#555" font-size="48" dy=".3em">Turkse Van kat</text></svg>


### PR DESCRIPTION
## Summary
- embed Comic Sans font in all placeholder SVGs
- document SVG font configuration in the README

## Testing
- `npm install`
- `npm run lint`
- `npm test`
- `npx jest tests --runInBand --colors=false`

------
https://chatgpt.com/codex/tasks/task_e_6859547f7970832e9804081a9619f130