### PR TITLE
Add fullscreen toggle for session

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ Gebruik flitskaarte; tel of trek vinnig af.
 ## Navigation
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
+The session page also includes a small fullscreen toggle so flashcards can fill the entire screen on phones.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
 Parents can also jump to any of the 41 weeks from the Dashboard. Selecting a week now reveals a simple confirmation panel with **Continue** and **Cancel** buttons. The page automatically scrolls this panel into view so parents don't miss it on long lists. Choosing Continue jumps directly to the session while Cancel keeps you on the Dashboard. If you try to jump outside the available range, the app logs a warning in the browser console.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.

--- a/src/components/FullscreenButton.jsx
+++ b/src/components/FullscreenButton.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types'
+
+const FullscreenButton = ({ onClick, isFullscreen }) => (
+  <button
+    type="button"
+    aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+    onClick={onClick}
+    className="icon-btn hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+  >
+    {isFullscreen ? '❌' : '⤢'}
+  </button>
+)
+
+FullscreenButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isFullscreen: PropTypes.bool,
+}
+
+FullscreenButton.defaultProps = {
+  isFullscreen: false,
+}
+
+export default FullscreenButton

--- a/src/components/FullscreenButton.test.jsx
+++ b/src/components/FullscreenButton.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import FullscreenButton from './FullscreenButton'
+
+describe('FullscreenButton', () => {
+  it('fires onClick when pressed', () => {
+    const onClick = jest.fn()
+    render(<FullscreenButton onClick={onClick} />)
+    fireEvent.click(screen.getByRole('button', { name: /enter fullscreen/i }))
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useContent } from '../contexts/ContentProvider'
 import LoadingSkeleton from '../components/LoadingSkeleton'
@@ -7,16 +7,35 @@ import LanguageModule from '../modules/LanguageModule';
 import MathModule from '../modules/MathModule';
 import EncyclopediaModule from '../modules/EncyclopediaModule';
 import ConfettiToast from '../components/ConfettiToast'
+import FullscreenButton from '../components/FullscreenButton'
 
 const Session = () => {
   const navigate = useNavigate()
   const { progress, weekData, loading, error, completeSession } = useContent()
   const [step, setStep] = useState(0)
   const [showToast, setShowToast] = useState(false)
+  const containerRef = useRef(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
 
   useEffect(() => {
     if (!loading) window.scrollTo(0, 0);
   }, [step, loading]);
+
+  useEffect(() => {
+    const handleChange = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+    document.addEventListener('fullscreenchange', handleChange)
+    return () => document.removeEventListener('fullscreenchange', handleChange)
+  }, [])
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement && containerRef.current?.requestFullscreen) {
+      containerRef.current.requestFullscreen()
+    } else if (document.exitFullscreen) {
+      document.exitFullscreen()
+    }
+  }
 
   if (loading) {
     return <LoadingSkeleton />
@@ -51,7 +70,17 @@ const Session = () => {
   return (
     <>
       <Header />
-      <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20">
+      <div
+        ref={containerRef}
+        data-testid="session-container"
+        className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20"
+      >
+      <div className="flex justify-end">
+        <FullscreenButton
+          onClick={toggleFullscreen}
+          isFullscreen={isFullscreen}
+        />
+      </div>
 
       {step === 0 && <LanguageModule words={weekData.language} />}
       {step === titles.indexOf('🔢 Math') && (

--- a/src/screens/Session.test.jsx
+++ b/src/screens/Session.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { AuthProvider } from '../contexts/AuthProvider'
 import Session from './Session'
@@ -51,5 +51,31 @@ describe('Session screen', () => {
       </MemoryRouter>,
     )
     expect(screen.getByTestId('app-header')).toBeInTheDocument()
+  })
+
+  it('toggles fullscreen on button press', () => {
+    const requestFullscreen = jest.fn()
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      weekData: {
+        language: ['one'],
+        mathWindowStart: 1,
+        encyclopedia: [{ image: 'a', title: 'A', fact: 'fact' }],
+      },
+      loading: false,
+      error: null,
+      completeSession: jest.fn(),
+    })
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Session />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    const container = screen.getByTestId('session-container')
+    container.requestFullscreen = requestFullscreen
+    fireEvent.click(screen.getByRole('button', { name: /enter fullscreen/i }))
+    expect(requestFullscreen).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- add FullscreenButton component and tests
- implement fullscreen toggle in Session screen
- test fullscreen behavior
- document fullscreen feature in README

## Testing
- `npm run lint`
- `npm test`
- `npx jest tests --runInBand --color`

------
https://chatgpt.com/codex/tasks/task_e_68595e90f3a0832eb6503d36e4628fd7