### PR TITLE
Fix mobile fullscreen toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ Gebruik flitskaarte; tel of trek vinnig af.
 ## Navigation
 
 The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
-The session page also includes a small fullscreen toggle so flashcards can fill the entire screen on phones.
+The session page also includes a small fullscreen toggle so flashcards can fill the entire screen on phones. This now detects vendor-prefixed fullscreen APIs so mobile Safari and older Android browsers can reliably enter and exit fullscreen mode.
 Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
 Parents can also jump to any of the 41 weeks from the Dashboard. Selecting a week now reveals a simple confirmation panel with **Continue** and **Cancel** buttons. The page automatically scrolls this panel into view so parents don't miss it on long lists. Choosing Continue jumps directly to the session while Cancel keeps you on the Dashboard. If you try to jump outside the available range, the app logs a warning in the browser console.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -23,17 +23,48 @@ const Session = () => {
 
   useEffect(() => {
     const handleChange = () => {
-      setIsFullscreen(!!document.fullscreenElement)
+      const el =
+        document.fullscreenElement ||
+        document.webkitFullscreenElement ||
+        document.mozFullScreenElement ||
+        document.msFullscreenElement
+      setIsFullscreen(!!el)
     }
+
     document.addEventListener('fullscreenchange', handleChange)
-    return () => document.removeEventListener('fullscreenchange', handleChange)
+    document.addEventListener('webkitfullscreenchange', handleChange)
+    document.addEventListener('mozfullscreenchange', handleChange)
+    document.addEventListener('MSFullscreenChange', handleChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', handleChange)
+      document.removeEventListener('webkitfullscreenchange', handleChange)
+      document.removeEventListener('mozfullscreenchange', handleChange)
+      document.removeEventListener('MSFullscreenChange', handleChange)
+    }
   }, [])
 
   const toggleFullscreen = () => {
-    if (!document.fullscreenElement && containerRef.current?.requestFullscreen) {
-      containerRef.current.requestFullscreen()
-    } else if (document.exitFullscreen) {
-      document.exitFullscreen()
+    const el = containerRef.current || document.documentElement
+    const isFs =
+      document.fullscreenElement ||
+      document.webkitFullscreenElement ||
+      document.mozFullScreenElement ||
+      document.msFullscreenElement
+
+    if (!isFs) {
+      const requestFn =
+        el.requestFullscreen ||
+        el.webkitRequestFullscreen ||
+        el.mozRequestFullScreen ||
+        el.msRequestFullscreen
+      if (requestFn) requestFn.call(el)
+    } else {
+      const exitFn =
+        document.exitFullscreen ||
+        document.webkitExitFullscreen ||
+        document.mozCancelFullScreen ||
+        document.msExitFullscreen
+      if (exitFn) exitFn.call(document)
     }
   }
 

--- a/src/screens/Session.test.jsx
+++ b/src/screens/Session.test.jsx
@@ -78,4 +78,31 @@ describe('Session screen', () => {
     fireEvent.click(screen.getByRole('button', { name: /enter fullscreen/i }))
     expect(requestFullscreen).toHaveBeenCalled()
   })
+
+  it('falls back to vendor-prefixed fullscreen APIs', () => {
+    const webkitRequestFullscreen = jest.fn()
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      weekData: {
+        language: ['one'],
+        mathWindowStart: 1,
+        encyclopedia: [{ image: 'a', title: 'A', fact: 'fact' }],
+      },
+      loading: false,
+      error: null,
+      completeSession: jest.fn(),
+    })
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <Session />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    const container = screen.getByTestId('session-container')
+    container.requestFullscreen = undefined
+    container.webkitRequestFullscreen = webkitRequestFullscreen
+    fireEvent.click(screen.getByRole('button', { name: /enter fullscreen/i }))
+    expect(webkitRequestFullscreen).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- improve fullscreen detection with vendor-prefixed fallbacks
- add tests for vendor-prefixed fullscreen API usage
- document improved mobile fullscreen support

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859627b1174832e81ea9f23bf872e60