### PR TITLE
Increase encyclopedia image height on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,13 +886,13 @@ The progress table now uses `table-fixed` so its seven columns fit within a
 360&nbsp;px wide viewport, and the action buttons are arranged in a single-column
 grid that expands to four columns on larger screens.
 Encyclopedia images now use an `.encyclopedia-thumb` class. On small screens
-images are square using `aspect-ratio: 1 / 1` so they fill most of the
-flashcard, while at the `md` breakpoint and above the aspect ratio reverts to
-`16 / 9` to match the 640×360 smart-crop returned by `/api/photos`. A
-`zoom-img` class adds a gentle scale animation on hover starting at the `md`
-breakpoint, leaving touch devices unaffected. Facts are displayed below the
-carousel progress dots similar to the Math module so the image and name remain
-prominent within the card.
+images use a portrait ratio of `aspect-ratio: 3 / 4` so they take up even more
+vertical space within the flashcard. At the `md` breakpoint and above the aspect
+ratio reverts to `16 / 9` to match the 640×360 smart-crop returned by
+`/api/photos`. A `zoom-img` class adds a gentle scale animation on hover starting
+at the `md` breakpoint, leaving touch devices unaffected. Facts are displayed
+below the carousel progress dots similar to the Math module so the image and
+name remain prominent within the card.
 
 Full-screen areas leverage viewport units so layouts adapt to device height.
 The math board scales with the viewport width while carousels always take up at

--- a/src/index.css
+++ b/src/index.css
@@ -109,7 +109,7 @@
 
   /* Keep encyclopedia images consistent regardless of width */
   .encyclopedia-thumb {
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 3 / 4;
     object-fit: cover;
   }
   @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- let encyclopedia images use a 3:4 aspect ratio on small screens
- document portrait ratio for encyclopedia images

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685966fad1f0832ea0573f020d52542a