### PR TITLE
Fix language module scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ the API routes, while React components rely on **React Testing Library**.
   `query` field with an English search term used for fetching photos
 - `src/utils/fetchWeek.js` – helper to fetch a week's JSON by number
 - `src/utils/encyclopediaImages.js` – imports encyclopedia images using Vite's glob feature
- - Language words now display in an even larger lowercase font using a
-   `language-word` class so toddlers can easily read them on phones
+ - Language words render in a large lowercase font using the `language-word`
+   class. The font size automatically shrinks for long words so everything stays
+   inside the card on small screens.
 
 ## Curriculum Files
 
@@ -905,7 +906,8 @@ name remain prominent within the card.
 short rows of seven week buttons with progress info below. The math practice
 screen shows four non-overlapping dots inside a square area roughly 70 % of the
 viewport width. Language slides fill most of the width thanks to the
-`language-word` class. Forms and buttons stretch across the width but remain
+`language-word` class, which scales long words down so they never overflow.
+Forms and buttons stretch across the width but remain
 capped at `max-w-xs`. These layouts were verified with browser device emulation to ensure
 no horizontal scrolling occurs.
 

--- a/src/modules/LanguageModule.jsx
+++ b/src/modules/LanguageModule.jsx
@@ -4,11 +4,21 @@ const shuffle = (arr) => [...arr].sort(() => Math.random() - 0.5)
 
 const LanguageModule = ({ words }) => {
   const items = shuffle(words)
+
+  const fontSizeForWord = (word) => {
+    const maxSize = 20 // vw
+    const size = Math.min(maxSize, 100 / Math.max(word.length, 1))
+    return `${size}vw`
+  }
+
   return (
     <Carousel
       items={items}
       renderItem={(word) => (
-        <div className="language-word font-bold lowercase leading-none">
+        <div
+          className="language-word font-bold lowercase leading-none"
+          style={{ fontSize: fontSizeForWord(word) }}
+        >
           {word}
         </div>
       )}


### PR DESCRIPTION
## Summary
- scale LanguageModule text based on word length
- document auto-shrinking `language-word` styling in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596c6c09a4832eaae3087b4c90a1ef