### PR TITLE
Adjust session colors

### DIFF
--- a/src/modules/EncyclopediaModule.jsx
+++ b/src/modules/EncyclopediaModule.jsx
@@ -54,7 +54,7 @@ const EncyclopediaModule = ({ cards }) => {
           )
         }}
       />
-      <p className="text-gray-600">{items[index]?.fact}</p>
+      <p className="text-white">{items[index]?.fact}</p>
     </div>
   )
 }

--- a/src/modules/MathModule.jsx
+++ b/src/modules/MathModule.jsx
@@ -105,28 +105,28 @@ const MathModule = ({
         renderItem={(n) => <DotBoard count={n} />}
       />
       {showCountingText && (
-        <div className="text-lg font-semibold">{countingText}</div>
+        <div className="text-lg font-semibold text-white">{countingText}</div>
       )}
       {sum && (
-        <div className="text-lg font-semibold">
+        <div className="text-lg font-semibold text-white">
           {sum.a} + {sum.b}
           {sum.c !== undefined ? ` + ${sum.c}` : ''} = {sum.sum}
         </div>
       )}
       {difference && (
-        <div className="text-lg font-semibold">
+        <div className="text-lg font-semibold text-white">
           {difference.a} - {difference.b}
           {difference.c !== undefined ? ` - ${difference.c}` : ''} ={' '}
           {difference.difference}
         </div>
       )}
       {product && (
-        <div className="text-lg font-semibold">
+        <div className="text-lg font-semibold text-white">
           {product.a} × {product.b} = {product.product}
         </div>
       )}
       {quotient && (
-        <div className="text-lg font-semibold">
+        <div className="text-lg font-semibold text-white">
           {quotient.a} ÷ {quotient.b} = {quotient.quotient}
         </div>
       )}

--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -104,13 +104,16 @@ const Session = () => {
       <div
         ref={containerRef}
         data-testid="session-container"
+        className="min-h-screen bg-black"
+      >
+      <div
         className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20"
       >
-      <div className="flex justify-end">
-        <FullscreenButton
-          onClick={toggleFullscreen}
-          isFullscreen={isFullscreen}
-        />
+        <div className="flex justify-end">
+          <FullscreenButton
+            onClick={toggleFullscreen}
+            isFullscreen={isFullscreen}
+          />
       </div>
 
       {step === 0 && <LanguageModule words={weekData.language} />}
@@ -155,6 +158,7 @@ const Session = () => {
           }}
         />
       )}
+      </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- darken session background while keeping cards white
- show white facts and math info below carousels
- keep tests and linting passing

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685970378540832ebbc94e6fc01cf1d6