### PR TITLE
UI: set Session page background to black

### DIFF
--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -99,16 +99,13 @@ const Session = () => {
   const handlePrev = () => step > 0 && setStep(step - 1);
 
   return (
-    <>
+    <div
+      ref={containerRef}
+      data-testid="session-container"
+      className="bg-black min-h-screen flex flex-col"
+    >
       <Header />
-      <div
-        ref={containerRef}
-        data-testid="session-container"
-        className="min-h-screen bg-black"
-      >
-      <div
-        className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20"
-      >
+      <div className="max-w-md mx-auto px-4 py-8 space-y-6 text-center pt-20 flex-grow">
         <div className="flex justify-end">
           <FullscreenButton
             onClick={toggleFullscreen}
@@ -159,8 +156,7 @@ const Session = () => {
         />
       )}
       </div>
-      </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- ensure Session screen uses a black page background
- wrap header and content in the same container

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685973663f60832e89bf8f4475b5fdc9