### PR TITLE
Fix missing closing div in Session screen

### DIFF
--- a/src/screens/Session.jsx
+++ b/src/screens/Session.jsx
@@ -165,6 +165,7 @@ const Session = () => {
         />
       )}
       </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- fix unmatched div causing JSX parse error in Session screen

## Testing
- `npm run lint`
- `npm test --silent -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685976eb1c9c832e8678726999037987