### PR TITLE
Fix term1 week4 ID typo

### DIFF
--- a/public/terms/term1/weeks/week004.json
+++ b/public/terms/term1/weeks/week004.json
@@ -28,8 +28,8 @@
       "image": "/images/placeholder.png"
     },
     {
-      "id": "huiskraan",
-      "title": "Huiskraan",
+      "id": "hyskraan",
+      "title": "Hyskraan",
       "query": "Crane",
       "fact": "Used to lift heavy objects on site.",
       "image": "/images/placeholder.png"


### PR DESCRIPTION
## Summary
- fix spelling of "hyskraan" in week 4 term1 data

## Testing
- `npx jest tests --runInBand --color=false`

------
https://chatgpt.com/codex/tasks/task_e_685a8c005850832e9a16e958421748ab