### PR TITLE
Update week4 Encyclopedia with Stroper

### DIFF
--- a/public/terms/term1/weeks/week004.json
+++ b/public/terms/term1/weeks/week004.json
@@ -75,7 +75,14 @@
       "query": "Cement mixer",
       "fact": "Mixes cement for building.",
       "image": "/images/placeholder.png"
-    }
+    },
+    {
+      "id": "stroper",
+      "title": "Stroper",
+      "query": "Harvester",
+      "fact": "Machine that harvests crops.",
+      "image": "/images/placeholder.png"
+    },
   ],
   "mathWindowLength": 10,
   "mathShuffleFirstHalf": true


### PR DESCRIPTION
## Summary
- include 'Stroper' entry in the Term 1 Week 4 encyclopedia data

## Testing
- `npx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8d03da10832ea542cc8b43b4c61f