### PR TITLE
Prepare for native app launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,9 @@ npx cap open android
 npx cap open ios
 ```
 
+Additional steps for preparing the native release are tracked in
+[`tasks/native-launch-checklist.md`](tasks/native-launch-checklist.md).
+
 From there you can build and publish the app to the Play Store or App Store. For
 release builds remember to configure signing keys:
 

--- a/src/utils/fetchWeek.jsx
+++ b/src/utils/fetchWeek.jsx
@@ -1,6 +1,6 @@
 export async function fetchWeekData(week) {
   const id = String(week).padStart(3, '0');
-  const res = await fetch(\`/weeks/week\${id}.json\`);
+  const res = await fetch(`/weeks/week${id}.json`);
   if (!res.ok) throw new Error('Unable to load week data');
   return res.json();
 }

--- a/tasks/native-launch-checklist.md
+++ b/tasks/native-launch-checklist.md
@@ -1,0 +1,15 @@
+# Native App Launch Tasks
+
+This checklist captures steps to prepare FlinkDink for release on both iOS and Android using Capacitor.
+
+- [ ] **Audit dependencies** – verify all packages are up to date and compatible with Capacitor 5.
+- [ ] **Update icons and splash screens** for each platform under `ios/App/App/Assets.xcassets` and `android/app/src/main/res`.
+- [ ] **Configure environment variables** in `.env` and ensure `npx cap sync` propagates them to native projects.
+- [ ] **Enable offline caching** for week data and images to improve startup performance.
+- [ ] **Set up CI builds** that run `npm run build` followed by `npx cap sync` for both platforms.
+- [ ] **Run eslint and jest** as part of the build pipeline to catch issues early.
+- [ ] **Test on physical devices** covering a range of screen sizes and OS versions.
+- [ ] **Prepare App Store metadata** including screenshots and descriptions.
+- [ ] **Document submission steps** for both Google Play and App Store Connect.
+
+Keep this file updated as tasks are completed or new work is identified.

--- a/tests/fetchCleanPhoto.test.js
+++ b/tests/fetchCleanPhoto.test.js
@@ -1,13 +1,15 @@
 let fetchCleanPhoto
+let clearCache
 
 beforeAll(async () => {
-  ;({ default: fetchCleanPhoto } = await import('../utils/fetchCleanPhoto.js'))
+  ;({ default: fetchCleanPhoto, clearCache } = await import('../utils/fetchCleanPhoto.js'))
 })
 
 describe('fetchCleanPhoto', () => {
   afterEach(() => {
     jest.restoreAllMocks()
     delete global.fetch
+    clearCache()
   })
 
   test('returns first result', async () => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import request from 'supertest';
+import { clearCache } from '../utils/fetchCleanPhoto.js';
 
 let app;
 beforeAll(async () => {
@@ -58,6 +59,7 @@ describe('photo endpoint', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    clearCache();
   });
 
   test('returns photo URLs on success', async () => {


### PR DESCRIPTION
## Summary
- add caching to Unsplash photo fetches
- expose cache reset for tests
- create a native launch checklist
- document checklist in README
- fix typo in `fetchWeek.jsx`
- update tests to clear photo cache

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685abe22f9c0832e9c7a16882dfa9048