### PR TITLE
Add ProfileProvider context

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ term based on these fixed ranges.
 
 User progress is stored in `localStorage` under the key `progress-v1`. Each saved record contains a `version` field. If the stored version does not match the current application version, progress is reset to defaults. Bump the version when changing the progress schema.
 
+## Child Profiles
+
+Multiple children can share the app by creating profiles. Profile data is saved
+in `localStorage` under the key `profiles-v1`. Each record stores a profile's
+`id`, `name`, `birthday`, `avatar` and `progress`. The `ProfileProvider`
+context exposes a `useProfiles` hook that returns the list of profiles, the
+currently selected profile and helper functions to create, edit, delete and
+select profiles.
+
 ## Home Screen
 
 The top of the page includes a sticky `NavBar` with a centered **FlinkDink**

--- a/src/contexts/ProfileProvider.jsx
+++ b/src/contexts/ProfileProvider.jsx
@@ -1,0 +1,92 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+const PROFILES_VERSION = 1;
+export const PROFILES_KEY = 'profiles-v1';
+
+const DEFAULT_DATA = {
+  version: PROFILES_VERSION,
+  profiles: [],
+  selectedId: null,
+};
+
+const ProfileContext = createContext();
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useProfiles() {
+  return useContext(ProfileContext);
+}
+
+function loadData() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
+    if (
+      stored &&
+      stored.version === PROFILES_VERSION &&
+      Array.isArray(stored.profiles)
+    ) {
+      return stored;
+    }
+  } catch {
+    // ignore JSON errors
+  }
+  return DEFAULT_DATA;
+}
+
+export const ProfileProvider = ({ children }) => {
+  const { profiles: initProfiles, selectedId: initSelected } = loadData();
+  const [profiles, setProfiles] = useState(initProfiles);
+  const [selectedId, setSelectedId] = useState(initSelected);
+
+  useEffect(() => {
+    localStorage.setItem(
+      PROFILES_KEY,
+      JSON.stringify({ version: PROFILES_VERSION, profiles, selectedId }),
+    );
+  }, [profiles, selectedId]);
+
+  const createProfile = (profile) => {
+    const id =
+      profile.id || (crypto.randomUUID ? crypto.randomUUID() : Date.now().toString());
+    const newProfile = { ...profile, id };
+    setProfiles((prev) => [...prev, newProfile]);
+    setSelectedId(id);
+  };
+
+  const editProfile = (id, updates) => {
+    setProfiles((prev) => prev.map((p) => (p.id === id ? { ...p, ...updates } : p)));
+  };
+
+  const deleteProfile = (id) => {
+    setProfiles((prev) => prev.filter((p) => p.id !== id));
+    setSelectedId((prev) => (prev === id ? null : prev));
+  };
+
+  const selectProfile = (id) => {
+    if (profiles.some((p) => p.id === id)) {
+      setSelectedId(id);
+    }
+  };
+
+  const selectedProfile = profiles.find((p) => p.id === selectedId) || null;
+
+  return (
+    <ProfileContext.Provider
+      value={{
+        profiles,
+        selectedProfile,
+        selectedId,
+        createProfile,
+        editProfile,
+        deleteProfile,
+        selectProfile,
+      }}
+    >
+      {children}
+    </ProfileContext.Provider>
+  );
+};

--- a/src/contexts/ProfileProvider.test.jsx
+++ b/src/contexts/ProfileProvider.test.jsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { useEffect } from 'react';
+import { ProfileProvider, useProfiles, PROFILES_KEY } from './ProfileProvider';
+
+const Display = () => {
+  const { selectedProfile } = useProfiles();
+  return (
+    <div data-testid="selected">
+      {selectedProfile ? selectedProfile.name : 'none'}
+    </div>
+  );
+};
+
+const Caller = ({ action }) => {
+  const ctx = useProfiles();
+  useEffect(() => {
+    action(ctx);
+  }, [ctx, action]);
+  return null;
+};
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('ProfileProvider storage', () => {
+  test('loads stored profiles on init', () => {
+    localStorage.setItem(
+      PROFILES_KEY,
+      JSON.stringify({
+        version: 1,
+        profiles: [{ id: '1', name: 'Tim' }],
+        selectedId: '1',
+      }),
+    );
+
+    render(
+      <ProfileProvider>
+        <Display />
+      </ProfileProvider>,
+    );
+
+    expect(screen.getByTestId('selected')).toHaveTextContent('Tim');
+  });
+
+  test('createProfile saves to localStorage and selects', async () => {
+    let createFn;
+
+    render(
+      <ProfileProvider>
+        <Caller action={({ createProfile }) => { createFn = createProfile; }} />
+        <Display />
+      </ProfileProvider>,
+    );
+
+    act(() => createFn({ name: 'Sam' }));
+
+    await waitFor(() => expect(screen.getByTestId('selected')).toHaveTextContent('Sam'));
+    const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
+    expect(stored.profiles[0].name).toBe('Sam');
+    expect(stored.selectedId).toBe(stored.profiles[0].id);
+  });
+});
+
+describe('selectProfile', () => {
+  test('updates selectedId and persisted data', () => {
+    localStorage.setItem(
+      PROFILES_KEY,
+      JSON.stringify({
+        version: 1,
+        profiles: [
+          { id: '1', name: 'One' },
+          { id: '2', name: 'Two' },
+        ],
+        selectedId: '1',
+      }),
+    );
+
+    render(
+      <ProfileProvider>
+        <Display />
+        <Caller action={({ selectProfile }) => selectProfile('2')} />
+      </ProfileProvider>,
+    );
+
+    expect(screen.getByTestId('selected')).toHaveTextContent('Two');
+    const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
+    expect(stored.selectedId).toBe('2');
+  });
+});


### PR DESCRIPTION
## Summary
- manage child profiles with new `ProfileProvider`
- expose `useProfiles` hook for profile actions
- test profile persistence and selection
- document profile storage in README

## Testing
- `npm run lint`
- `npm test` *(fails: auth endpoints register/login returned HTTP 422)*

------
https://chatgpt.com/codex/tasks/task_e_685b15e580a0832ebc51c69a9056f977