### PR TITLE
Add onboarding flow for profile creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ context exposes a `useProfiles` hook that returns the list of profiles, the
 currently selected profile and helper functions to create, edit, delete and
 select profiles.
 
+When no profiles exist, the **OnboardingHome** screen prompts parents to create
+a profile. The form collects the child's name, date of birth and an optional
+emoji avatar. Submitting the form saves the profile via `ProfileProvider` and
+redirects to the kid selection page.
+
 ## Home Screen
 
 The top of the page includes a sticky `NavBar` with a centered **FlinkDink**

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,43 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
 import Home from './screens/Home'
 import Session from './screens/Session'
 import Dashboard from './screens/Dashboard'
 import Login from './screens/Login'
 import SignUp from './screens/SignUp'
+import OnboardingHome from './screens/OnboardingHome'
+import SelectKid from './screens/SelectKid'
 import { ContentProvider } from './contexts/ContentProvider'
 import { AuthProvider } from './contexts/AuthProvider'
+import { ProfileProvider, useProfiles } from './contexts/ProfileProvider'
 import ErrorBanner from './components/ErrorBanner'
 import './App.css'
+
+const RoutesWithProfiles = () => {
+  const { profiles } = useProfiles()
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<SignUp />} />
+      <Route
+        path="/"
+        element={profiles.length === 0 ? <OnboardingHome /> : <Navigate to="/select-kid" />}
+      />
+      <Route path="/select-kid" element={<SelectKid />} />
+      <Route path="/session" element={<Session />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+    </Routes>
+  )
+}
 
 const App = () => (
   <BrowserRouter>
     <AuthProvider>
-      <ContentProvider>
-        <ErrorBanner />
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/" element={<Home />} />
-          <Route path="/session" element={<Session />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-        </Routes>
-      </ContentProvider>
+      <ProfileProvider>
+        <ContentProvider>
+          <ErrorBanner />
+          <RoutesWithProfiles />
+        </ContentProvider>
+      </ProfileProvider>
     </AuthProvider>
   </BrowserRouter>
 )

--- a/src/screens/OnboardingHome.jsx
+++ b/src/screens/OnboardingHome.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useProfiles } from '../contexts/ProfileProvider';
+
+const EMOJIS = ['🐶', '🐱', '🐰', '🦁', '🐵', '🐸', '🐼', '🦊'];
+
+function randomEmoji() {
+  return EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
+}
+
+export default function OnboardingHome() {
+  const { createProfile } = useProfiles();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [birthday, setBirthday] = useState('');
+  const [avatar, setAvatar] = useState(randomEmoji());
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
+    if (birthday && Number.isNaN(new Date(birthday).getTime())) {
+      setError('Invalid date');
+      return;
+    }
+    createProfile({ name: name.trim(), birthday, avatar });
+    navigate('/select-kid');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 bg-white p-6 shadow rounded w-full max-w-xs"
+      >
+        <h1 className="text-xl font-bold text-center">Welcome!</h1>
+        {error && (
+          <div className="text-red-600" role="alert">
+            {error}
+          </div>
+        )}
+        <label htmlFor="name" className="sr-only">
+          Name
+        </label>
+        <input
+          id="name"
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border rounded p-2 w-full"
+        />
+        <label htmlFor="dob" className="sr-only">
+          Date of Birth
+        </label>
+        <input
+          id="dob"
+          type="date"
+          value={birthday}
+          onChange={(e) => setBirthday(e.target.value)}
+          className="border rounded p-2 w-full"
+          aria-label="date of birth"
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-3xl" aria-label="avatar">
+            {avatar}
+          </span>
+          <button
+            type="button"
+            className="underline text-sm"
+            onClick={() => setAvatar(randomEmoji())}
+          >
+            Random Avatar
+          </button>
+        </div>
+        <button
+          type="submit"
+          className="bg-indigo-600 text-white w-full py-2 rounded"
+        >
+          Create Profile
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/screens/OnboardingHome.test.jsx
+++ b/src/screens/OnboardingHome.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProfileProvider, PROFILES_KEY } from '../contexts/ProfileProvider';
+import OnboardingHome from './OnboardingHome';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+  localStorage.clear();
+});
+
+test('submits valid form and redirects', () => {
+  render(
+    <MemoryRouter>
+      <ProfileProvider>
+        <OnboardingHome />
+      </ProfileProvider>
+    </MemoryRouter>
+  );
+
+  fireEvent.change(screen.getByLabelText(/name/i), {
+    target: { value: 'Sam' },
+  });
+  fireEvent.change(screen.getByLabelText(/date of birth/i), {
+    target: { value: '2020-01-01' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /create profile/i }));
+
+  expect(mockNavigate).toHaveBeenCalledWith('/select-kid');
+  const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
+  expect(stored.profiles[0].name).toBe('Sam');
+});
+
+test('shows error for missing name', () => {
+  render(
+    <MemoryRouter>
+      <ProfileProvider>
+        <OnboardingHome />
+      </ProfileProvider>
+    </MemoryRouter>
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /create profile/i }));
+  expect(screen.getByRole('alert')).toHaveTextContent(/name is required/i);
+});
+

--- a/src/screens/SelectKid.jsx
+++ b/src/screens/SelectKid.jsx
@@ -1,0 +1,12 @@
+import { useProfiles } from '../contexts/ProfileProvider';
+
+export default function SelectKid() {
+  const { profiles } = useProfiles();
+  return (
+    <div className="p-4" data-testid="select-kid">
+      {profiles.map((p) => (
+        <div key={p.id}>{p.name}</div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create **OnboardingHome** screen with profile form
- route new users to the onboarding screen and existing users to `/select-kid`
- add placeholder `SelectKid` screen
- document onboarding flow in README
- test onboarding behaviour

## Testing
- `npx jest tests src/screens/OnboardingHome.test.jsx --runInBand --verbose`

------
https://chatgpt.com/codex/tasks/task_e_685b18154314832ea475bb661e448cc3