### PR TITLE
Add KidSelector component with profile management

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ a profile. The form collects the child's name, date of birth and an optional
 emoji avatar. Submitting the form saves the profile via `ProfileProvider` and
 redirects to the kid selection page.
 
+### Kid Selector
+
+Saved profiles appear in a responsive grid rendered by the **KidSelector**
+component. Each card shows the child's avatar emoji, name and calculated age.
+Tapping a card selects that profile and navigates to the learning hub. Cards
+include ✏️ and 🗑️ buttons for editing or deleting a profile. A final "➕ Add
+Another Child" card links back to the onboarding form.
+
 ## Home Screen
 
 The top of the page includes a sticky `NavBar` with a centered **FlinkDink**

--- a/src/components/KidSelector.jsx
+++ b/src/components/KidSelector.jsx
@@ -1,0 +1,97 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useProfiles } from '../contexts/ProfileProvider';
+
+function calcAge(birthday) {
+  if (!birthday) return '-';
+  const birth = new Date(birthday);
+  if (Number.isNaN(birth.getTime())) return '-';
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+export default function KidSelector() {
+  const {
+    profiles,
+    selectProfile,
+    deleteProfile,
+    editProfile,
+  } = useProfiles();
+  const navigate = useNavigate();
+
+  const handleSelect = (id) => {
+    selectProfile(id);
+    navigate('/learning-hub');
+  };
+
+  const handleDelete = (e, id) => {
+    e.stopPropagation();
+    if (window.confirm('Delete this profile?')) {
+      deleteProfile(id);
+    }
+  };
+
+  const handleEdit = (e, id, name) => {
+    e.stopPropagation();
+    const newName = window.prompt('New name', name);
+    if (newName) {
+      editProfile(id, { name: newName });
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {profiles.map((p) => (
+          <div
+            key={p.id}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleSelect(p.id)}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') handleSelect(p.id);
+            }}
+            aria-label={`Select ${p.name}`}
+            className="card space-y-1 text-center cursor-pointer"
+          >
+            <div className="text-6xl" aria-label="avatar">
+              {p.avatar}
+            </div>
+            <div className="font-semibold">{p.name}</div>
+            <div className="text-sm text-gray-600">
+              {calcAge(p.birthday)} years
+            </div>
+            <div className="flex justify-center space-x-2 pt-2">
+              <button
+                type="button"
+                onClick={(e) => handleEdit(e, p.id, p.name)}
+                aria-label={`Edit ${p.name}`}
+                className="icon-btn hover:bg-gray-200"
+              >
+                ✏️
+              </button>
+              <button
+                type="button"
+                onClick={(e) => handleDelete(e, p.id)}
+                aria-label={`Delete ${p.name}`}
+                className="icon-btn hover:bg-gray-200"
+              >
+                🗑️
+              </button>
+            </div>
+          </div>
+        ))}
+        <Link
+          to="/onboarding"
+          className="card flex items-center justify-center text-xl font-semibold"
+        >
+          ➕ Add Another Child
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/KidSelector.test.jsx
+++ b/src/components/KidSelector.test.jsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import KidSelector from './KidSelector';
+import { useProfiles } from '../contexts/ProfileProvider';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+jest.mock('../contexts/ProfileProvider');
+
+const profiles = [
+  { id: '1', name: 'Sam', birthday: '2020-01-01', avatar: '🐶' },
+  { id: '2', name: 'Tim', birthday: '2019-06-15', avatar: '🐱' },
+];
+
+beforeEach(() => {
+  useProfiles.mockReturnValue({
+    profiles,
+    selectProfile: jest.fn(),
+    deleteProfile: jest.fn(),
+    editProfile: jest.fn(),
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('selects profile and navigates to hub', () => {
+  const { selectProfile } = useProfiles.mock.results[0].value;
+  render(
+    <MemoryRouter>
+      <KidSelector />
+    </MemoryRouter>,
+  );
+  fireEvent.click(screen.getByLabelText('Select Sam'));
+  expect(selectProfile).toHaveBeenCalledWith('1');
+  expect(mockNavigate).toHaveBeenCalledWith('/learning-hub');
+});
+
+test('deletes profile when confirmed', () => {
+  const { deleteProfile } = useProfiles.mock.results[0].value;
+  window.confirm = jest.fn(() => true);
+  render(
+    <MemoryRouter>
+      <KidSelector />
+    </MemoryRouter>,
+  );
+  fireEvent.click(screen.getByLabelText('Delete Sam'));
+  expect(window.confirm).toHaveBeenCalled();
+  expect(deleteProfile).toHaveBeenCalledWith('1');
+});
+
+test('edits profile name', () => {
+  const { editProfile } = useProfiles.mock.results[0].value;
+  window.prompt = jest.fn(() => 'Sally');
+  render(
+    <MemoryRouter>
+      <KidSelector />
+    </MemoryRouter>,
+  );
+  fireEvent.click(screen.getByLabelText('Edit Sam'));
+  expect(window.prompt).toHaveBeenCalled();
+  expect(editProfile).toHaveBeenCalledWith('1', { name: 'Sally' });
+});


### PR DESCRIPTION
## Summary
- add KidSelector component for selecting, editing and deleting child profiles
- include grid layout and navigation to /learning-hub
- document KidSelector in README
- test profile selection, deletion and editing

## Testing
- `npm run lint`
- `npm test` *(fails: auth endpoints due to ENETUNREACH when contacting Unsplash)*

------
https://chatgpt.com/codex/tasks/task_e_685b1ac3be18832e91d88285ba0f395d