### PR TITLE
Implement LearningHub dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,8 @@ Daily modules are listed in a small table labelled **"Weekly progress"**, where 
 
 Below the table is a row of control buttons arranged with `flex` and `flex-wrap` so they stack neatly on narrow screens. Each button label now starts with a small emoji, for example **"🔄 Reset Today"** and **"🗑️ Reset All"**. Selecting **Reset All** opens a confirmation dialog before all progress is cleared.
 
+After a child profile is selected, they land on a new **Learning Hub**. This dashboard greets them with their avatar, today's date, and the current week/day/session. From here kids can quickly continue the session or view their overall progress.
+
 ## Accessibility
 
 Carousel navigation buttons now include descriptive ARIA labels and retain their focus outlines for improved keyboard navigation.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom'
 import Home from './screens/Home'
 import Session from './screens/Session'
 import Dashboard from './screens/Dashboard'
+import LearningHub from './screens/LearningHub'
+import Progress from './screens/Progress'
 import Login from './screens/Login'
 import SignUp from './screens/SignUp'
 import OnboardingHome from './screens/OnboardingHome'
@@ -23,6 +25,8 @@ const RoutesWithProfiles = () => {
         element={profiles.length === 0 ? <OnboardingHome /> : <Navigate to="/select-kid" />}
       />
       <Route path="/select-kid" element={<SelectKid />} />
+      <Route path="/learning-hub" element={<LearningHub />} />
+      <Route path="/progress" element={<Progress />} />
       <Route path="/session" element={<Session />} />
       <Route path="/dashboard" element={<Dashboard />} />
     </Routes>

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -1,19 +1,5 @@
-import NavBar from '../components/NavBar';
-import Hero from '../components/Hero';
-import ProgressStrip from '../components/ProgressStrip';
-import ThemeList from '../components/ThemeList';
-import CTAButton from '../components/CTAButton';
+import { Navigate } from 'react-router-dom';
 
 export default function Home() {
-  return (
-    <div className="home-screen flex flex-col bg-gray-50">
-      <NavBar />
-      <main className="flex-grow flex flex-col items-center justify-center space-y-8 max-w-md w-11/12 md:w-4/5 mx-auto">
-        <Hero />
-        <ProgressStrip />
-        <ThemeList />
-        <CTAButton />
-      </main>
-    </div>
-  );
+  return <Navigate to="/learning-hub" replace />;
 }

--- a/src/screens/Home.test.jsx
+++ b/src/screens/Home.test.jsx
@@ -1,41 +1,17 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import { AuthProvider } from '../contexts/AuthProvider';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Home from './Home';
-import { useContent } from '../contexts/ContentProvider';
 
-jest.mock('../contexts/ContentProvider');
-
-describe('Home screen', () => {
-  it('renders hero, progress, themes and CTA', () => {
-    useContent.mockReturnValue({
-      progress: { week: 2, day: 3, session: 2 },
-      weekData: {
-        language: ['apple'],
-        mathWindowStart: 10,
-        encyclopedia: [{ title: 'Lion' }],
-      },
-      loading: false,
-    });
-
+describe('Home redirect', () => {
+  it('redirects to learning hub', () => {
     render(
-      <MemoryRouter>
-        <AuthProvider>
-          <Home />
-        </AuthProvider>
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/learning-hub" element={<div>Hub</div>} />
+        </Routes>
       </MemoryRouter>,
     );
-
-    expect(
-      screen.getByRole('heading', { name: /flinkdink flashcards/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Week 2 \u00B7 Day 3 \u00B7 Session 2'),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: /continue week 2 · day 3 · session 2/i }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getByText('Hub')).toBeInTheDocument();
   });
 });

--- a/src/screens/LearningHub.jsx
+++ b/src/screens/LearningHub.jsx
@@ -1,0 +1,61 @@
+import { Link } from 'react-router-dom';
+import { useProfiles } from '../contexts/ProfileProvider';
+import { useContent, TOTAL_WEEKS } from '../contexts/ContentProvider';
+
+export default function LearningHub() {
+  const { selectedProfile } = useProfiles();
+  const { progress } = useContent();
+  const { week, day, session } = progress;
+
+  const completedSessions = (week - 1) * 21 + (day - 1) * 3 + (session - 1);
+  const totalSessions = TOTAL_WEEKS * 7 * 3;
+  const percent = Math.round((completedSessions / totalSessions) * 100);
+
+  const today = new Date();
+  const weekday = today.toLocaleDateString('en-US', { weekday: 'long' });
+
+  if (!selectedProfile) {
+    return null;
+  }
+
+  return (
+    <div className="p-4 space-y-4" data-testid="learning-hub">
+      <h1 className="text-2xl font-bold mb-4 flex items-center gap-2">
+        <span aria-label="avatar">{selectedProfile.avatar}</span>
+        <span>
+          🎉 Welcome back, {selectedProfile.name}!
+        </span>
+      </h1>
+      <div className="space-y-1 text-center">
+        <p data-testid="session-info">
+          Week {week} · Day {day} · Session {session}
+        </p>
+        <p data-testid="date-info">
+          {weekday} · Week {week}, Day {day}
+        </p>
+      </div>
+      <div className="flex justify-center">
+        <div
+          className="w-24 h-24 ring-4 ring-green-400 rounded-full flex items-center justify-center animate-pulse text-center"
+          data-testid="progress-circle"
+        >
+          {percent}%
+        </div>
+      </div>
+      <div className="flex flex-col items-center space-y-2">
+        <Link
+          to="/session"
+          className="bg-purple-600 text-white rounded-xl px-4 py-2 w-full text-center"
+        >
+          Continue Session
+        </Link>
+        <Link
+          to="/progress"
+          className="border-2 border-gray-400 rounded-xl px-4 py-2 w-full text-center"
+        >
+          View Progress
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/LearningHub.test.jsx
+++ b/src/screens/LearningHub.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LearningHub from './LearningHub';
+import { useProfiles } from '../contexts/ProfileProvider';
+import { useContent } from '../contexts/ContentProvider';
+
+jest.mock('../contexts/ProfileProvider');
+jest.mock('../contexts/ContentProvider');
+
+describe('LearningHub', () => {
+  it('shows session info and action links', () => {
+    useProfiles.mockReturnValue({
+      selectedProfile: { name: 'Lila', avatar: '🐱' },
+    });
+    useContent.mockReturnValue({
+      progress: { week: 2, day: 3, session: 1 },
+    });
+
+    const today = new Date();
+    const weekday = today.toLocaleDateString('en-US', { weekday: 'long' });
+
+    render(
+      <MemoryRouter>
+        <LearningHub />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /welcome back, lila!/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('session-info')).toHaveTextContent(
+      'Week 2 \u00B7 Day 3 \u00B7 Session 1',
+    );
+    expect(screen.getByTestId('date-info')).toHaveTextContent(
+      `${weekday} · Week 2, Day 3`,
+    );
+    expect(screen.getByRole('link', { name: /continue session/i })).toHaveAttribute(
+      'href',
+      '/session',
+    );
+    expect(screen.getByRole('link', { name: /view progress/i })).toHaveAttribute(
+      'href',
+      '/progress',
+    );
+  });
+});

--- a/src/screens/Progress.jsx
+++ b/src/screens/Progress.jsx
@@ -1,0 +1,7 @@
+export default function Progress() {
+  return (
+    <div className="p-4" data-testid="progress-screen">
+      Progress Page
+    </div>
+  );
+}

--- a/utils/fetchCleanPhoto.js
+++ b/utils/fetchCleanPhoto.js
@@ -1,4 +1,4 @@
-import { breedMap } from '../server.js';
+import { breedMap } from './breedMap.js';
 const UNSPLASH_URL = 'https://api.unsplash.com/search/photos';
 
 const IMGIX_PARAMS = 'w=640&h=360&fit=crop&crop=faces,entropy';


### PR DESCRIPTION
## Summary
- create LearningHub screen with session info and actions
- add Progress placeholder screen
- route /learning-hub and /progress in App
- redirect Home screen to the Learning Hub
- update fetchCleanPhoto to import breedMap without side effects
- document new Learning Hub in README
- add unit tests for Home redirect and Learning Hub

## Testing
- `npm run lint`
- `npx jest tests --runInBand --verbose`

------
https://chatgpt.com/codex/tasks/task_e_685b1c2e1260832e92d5284b8158edd8