### PR TITLE
Add tabbed navigation bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,9 +811,9 @@ Gebruik flitskaarte; tel of trek vinnig af.
 - Session&nbsp;3 – `30 - 15 - 4 = 11`
 ## Navigation
 
-The application now uses a `NavBar` component on the home screen. It shows a back/home icon, a centered **FlinkDink** title, and a circular settings button. Other screens continue to display the progress header with week, day, and session information.
+The interface features a tabbed `NavBar` fixed to the bottom of the screen. Five tabs provide quick access to **Home**, **Profiles**, **Curriculum**, **Progress** and **Settings**. Each tab pairs a small emoji icon with a text label and the active tab is indicated using `aria-current="page"`.
 The session page includes a small fullscreen toggle on large screens so flashcards can fill the entire display. It still detects vendor-prefixed fullscreen APIs for older browsers.
-Clicking the settings button now opens a simple **Dashboard** route showing overall progress and reset options.
+Selecting the **Settings** tab opens the **Dashboard** where parents can review progress and reset options.
 Parents can also jump to any of the 41 weeks from the Dashboard. Selecting a week now reveals a simple confirmation panel with **Continue** and **Cancel** buttons. The page automatically scrolls this panel into view so parents don't miss it on long lists. Choosing Continue jumps directly to the session while Cancel keeps you on the Dashboard. If you try to jump outside the available range, the app logs a warning in the browser console.
 When unlocked, the Dashboard now shows a large progress header with your current week, day, session and streak. It reuses the same session dots as the home screen.
 Daily modules are listed in a small table labelled **"Weekly progress"**, where completed cells appear green.

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,46 +1,34 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import SettingsButton from './SettingsButton';
-import { useAuth } from '../contexts/authHelpers';
+import { NavLink, useLocation } from 'react-router-dom';
+
+const NAV_ITEMS = [
+  { to: '/learning-hub', label: 'Home', icon: '🏠' },
+  { to: '/select-kid', label: 'Profiles', icon: '👶' },
+  { to: '/session', label: 'Curriculum', icon: '📚' },
+  { to: '/progress', label: 'Progress', icon: '📈' },
+  { to: '/dashboard', label: 'Settings', icon: '⚙️' },
+];
 
 const NavBar = () => {
-  const navigate = useNavigate();
   const { pathname } = useLocation();
-  const { token, logout } = useAuth();
-  const handleSettings = () => navigate('/dashboard');
-  const common = 'w-full bg-gray-50 shadow-sm px-6 py-4 flex items-center justify-between';
-  const authButton = token ? (
-    <button type="button" onClick={logout} className="logouttext text-sm text-black underline ml-2">
-      Logout
-    </button>
-  ) : (
-    <div className="flex items-center space-x-2">
-      <Link to="/login" className="text-sm underline">Login</Link>
-      <Link to="/signup" className="text-sm underline">Sign Up</Link>
-    </div>
-  );
 
-  return pathname === '/' ? (
-    <nav className={common}>
-      <div className="flex-1" />
-      <span className="text-2xl font-bold text-indigo-600">FlinkDink</span>
-      <div className="flex items-center">
-        {authButton}
-        <SettingsButton onClick={handleSettings} />
-      </div>
-    </nav>
-  ) : (
-    <nav className={common}>
-      <Link
-        to="/"
-        aria-label="Home"
-        className="icon-btn hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-      >
-        🏠
-      </Link>
-      <div className="flex items-center">
-        {authButton}
-        <SettingsButton onClick={handleSettings} />
-      </div>
+  return (
+    <nav className="w-full bg-gray-50 shadow-sm px-2 py-2 flex justify-around fixed bottom-0" role="navigation">
+      {NAV_ITEMS.map((item) => {
+        const active = pathname.startsWith(item.to);
+        return (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={`flex flex-col items-center text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+              active ? 'text-indigo-600 font-bold' : 'text-gray-600'
+            }`}
+            aria-current={active ? 'page' : undefined}
+          >
+            <span aria-hidden="true">{item.icon}</span>
+            <span>{item.label}</span>
+          </NavLink>
+        );
+      })}
     </nav>
   );
 };

--- a/src/components/NavBar.test.jsx
+++ b/src/components/NavBar.test.jsx
@@ -4,43 +4,45 @@ import NavBar from './NavBar'
 import { AuthProvider } from '../contexts/AuthProvider'
 
 describe('NavBar', () => {
-  it('shows logo and settings on the home route', () => {
+  it('renders tab links with labels', () => {
     render(
-      <MemoryRouter initialEntries={["/"]}>
-        <AuthProvider>
-          <NavBar />
-        </AuthProvider>
-      </MemoryRouter>,
-    )
-    expect(screen.getByText('FlinkDink')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /home/i })).toBeNull()
-  })
-
-  it('shows home link on the session route', () => {
-    render(
-      <MemoryRouter initialEntries={["/session"]}>
+      <MemoryRouter initialEntries={["/learning-hub"]}>
         <AuthProvider>
           <NavBar />
         </AuthProvider>
       </MemoryRouter>,
     )
     expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /profiles/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /curriculum/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /progress/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
   })
 
-  it('navigates to dashboard when settings clicked', () => {
+  it('highlights the active tab', () => {
     render(
-      <MemoryRouter initialEntries={["/"]}>
+      <MemoryRouter initialEntries={["/progress"]}>
+        <AuthProvider>
+          <NavBar />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    const active = screen.getByRole('link', { name: /progress/i })
+    expect(active).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('navigates when a tab is clicked', () => {
+    render(
+      <MemoryRouter initialEntries={["/learning-hub"]}>
         <AuthProvider>
           <Routes>
-            <Route path="/" element={<NavBar />} />
+            <Route path="/learning-hub" element={<NavBar />} />
             <Route path="/dashboard" element={<div>Dash</div>} />
           </Routes>
         </AuthProvider>
       </MemoryRouter>,
     )
-    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    fireEvent.click(screen.getByRole('link', { name: /settings/i }))
     expect(screen.getByText('Dash')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- implement a tabbed NavBar with five sections
- adjust NavBar tests for new tabs
- document tabbed navigation in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b96cc630c832eb9732df47610e6d2