### PR TITLE
Add simple badge rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ Daily modules are listed in a small table labelled **"Weekly progress"**, where 
 
 Below the table is a row of control buttons arranged with `flex` and `flex-wrap` so they stack neatly on narrow screens. Each button label now starts with a small emoji, for example **"🔄 Reset Today"** and **"🗑️ Reset All"**. Selecting **Reset All** opens a confirmation dialog before all progress is cleared.
 
-After a child profile is selected, they land on a new **Learning Hub**. This dashboard greets them with their avatar, today's date, and the current week/day/session. From here kids can quickly continue the session or view their overall progress. A circular badge shows what percentage of weeks are complete.
+After a child profile is selected, they land on a new **Learning Hub**. This dashboard greets them with their avatar, today's date, and the current week/day/session. From here kids can quickly continue the session or view their overall progress. A circular badge shows what percentage of weeks are complete. Earned badges appear next to this progress circle. Kids unlock the **🎈 First Day** badge after completing their first day and a **🏅 5-Day Streak** badge once they log five days in a row.
 
 ## Accessibility
 

--- a/src/contexts/ContentProvider.jsx
+++ b/src/contexts/ContentProvider.jsx
@@ -7,6 +7,7 @@ import {
 } from 'react'
 import { fetchWeekData } from '../utils/fetchWeek'
 import { calculateWeekPercent } from '../utils/progress'
+import { useProfiles } from './ProfileProvider'
 
 const PROGRESS_VERSION = 1
 const PROGRESS_KEY = 'progress-v1'
@@ -45,6 +46,7 @@ function loadProgress() {
 }
 
 export const ContentProvider = ({ children }) => {
+  const { unlockBadge } = useProfiles();
   const [progress, setProgress] = useState(loadProgress())
   const [weekData, setWeekData] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -95,6 +97,8 @@ export const ContentProvider = ({ children }) => {
         // keep week/day/session at final values
       }
       streak += 1
+      if (streak === 1) unlockBadge('first-day')
+      if (streak === 5) unlockBadge('five-day-streak')
     }
     saveProgress({ week, day, session, streak })
   }

--- a/src/contexts/ProfileProvider.jsx
+++ b/src/contexts/ProfileProvider.jsx
@@ -29,7 +29,11 @@ function loadData() {
       stored.version === PROFILES_VERSION &&
       Array.isArray(stored.profiles)
     ) {
-      return stored;
+      const withBadges = stored.profiles.map((p) => ({
+        ...p,
+        badges: Array.isArray(p.badges) ? p.badges : [],
+      }));
+      return { ...stored, profiles: withBadges };
     }
   } catch {
     // ignore JSON errors
@@ -52,7 +56,7 @@ export const ProfileProvider = ({ children }) => {
   const createProfile = (profile) => {
     const id =
       profile.id || (crypto.randomUUID ? crypto.randomUUID() : Date.now().toString());
-    const newProfile = { ...profile, id };
+    const newProfile = { ...profile, id, badges: profile.badges || [] };
     setProfiles((prev) => [...prev, newProfile]);
     setSelectedId(id);
   };
@@ -72,6 +76,18 @@ export const ProfileProvider = ({ children }) => {
     }
   };
 
+  const unlockBadge = (badgeId) => {
+    if (!selectedId) return;
+    setProfiles((prev) =>
+      prev.map((p) => {
+        if (p.id !== selectedId) return p;
+        const badges = Array.isArray(p.badges) ? p.badges : [];
+        if (badges.includes(badgeId)) return p;
+        return { ...p, badges: [...badges, badgeId] };
+      }),
+    );
+  };
+
   const selectedProfile = profiles.find((p) => p.id === selectedId) || null;
 
   return (
@@ -84,6 +100,7 @@ export const ProfileProvider = ({ children }) => {
         editProfile,
         deleteProfile,
         selectProfile,
+        unlockBadge,
       }}
     >
       {children}

--- a/src/contexts/ProfileProvider.test.jsx
+++ b/src/contexts/ProfileProvider.test.jsx
@@ -88,3 +88,46 @@ describe('selectProfile', () => {
     expect(stored.selectedId).toBe('2');
   });
 });
+
+describe('unlockBadge', () => {
+  test('adds badge to selected profile and persists', () => {
+    let createFn;
+    let unlockFn;
+    render(
+      <ProfileProvider>
+        <Caller
+          action={({ createProfile, unlockBadge }) => {
+            createFn = createProfile;
+            unlockFn = unlockBadge;
+          }}
+        />
+      </ProfileProvider>,
+    );
+
+    act(() => createFn({ name: 'Mia' }));
+    act(() => unlockFn('first-day'));
+    const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
+    expect(stored.profiles[0].badges).toContain('first-day');
+  });
+
+  test('does not duplicate badges', () => {
+    let createFn;
+    let unlockFn;
+    render(
+      <ProfileProvider>
+        <Caller
+          action={({ createProfile, unlockBadge }) => {
+            createFn = createProfile;
+            unlockFn = unlockBadge;
+          }}
+        />
+      </ProfileProvider>,
+    );
+
+    act(() => createFn({ name: 'Mia' }));
+    act(() => unlockFn('first-day'));
+    act(() => unlockFn('first-day'));
+    const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
+    expect(stored.profiles[0].badges).toEqual(['first-day']);
+  });
+});

--- a/src/screens/LearningHub.jsx
+++ b/src/screens/LearningHub.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useProfiles } from '../contexts/ProfileProvider';
 import { useContent } from '../contexts/ContentProvider';
+import { BADGE_MAP } from '../utils/badges';
 
 export default function LearningHub() {
   const { selectedProfile } = useProfiles();
@@ -38,6 +39,15 @@ export default function LearningHub() {
           {weekPercent}%
         </div>
       </div>
+      {selectedProfile.badges.length > 0 && (
+        <div className="flex justify-center space-x-2" data-testid="badge-list">
+          {selectedProfile.badges.map((b) => (
+            <span key={b} role="img" aria-label={BADGE_MAP[b].label}>
+              {BADGE_MAP[b].icon}
+            </span>
+          ))}
+        </div>
+      )}
       <div className="flex flex-col items-center space-y-2">
         <Link
           to="/session"

--- a/src/screens/LearningHub.test.jsx
+++ b/src/screens/LearningHub.test.jsx
@@ -45,4 +45,22 @@ describe('LearningHub', () => {
     );
     expect(screen.getByTestId('progress-circle')).toHaveTextContent('2%');
   });
+
+  it('displays earned badges', () => {
+    useProfiles.mockReturnValue({
+      selectedProfile: { name: 'Meg', avatar: '🐶', badges: ['first-day'] },
+    });
+    useContent.mockReturnValue({
+      progress: { week: 1, day: 1, session: 1 },
+      weekPercent: 1,
+    });
+
+    render(
+      <MemoryRouter>
+        <LearningHub />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('badge-list')).toHaveTextContent('🎈');
+  });
 });

--- a/src/utils/badges.js
+++ b/src/utils/badges.js
@@ -1,0 +1,4 @@
+export const BADGE_MAP = {
+  'first-day': { icon: '🎈', label: 'First Day Complete' },
+  'five-day-streak': { icon: '🏅', label: '5-Day Streak' },
+};


### PR DESCRIPTION
## Summary
- store a list of earned badges per child profile
- show earned badges in the Learning Hub
- unlock badges when hitting day and streak milestones
- document the new reward system in the README
- test badge unlocking logic and badge UI

## Testing
- `npm install`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b9cbfc4e4832e83b31c69e19f11e8