### PR TITLE
Add SelectKid screen styling and age utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ You can repeat these steps to create profiles for multiple children.
 
 Saved profiles appear in a responsive grid rendered by the **KidSelector**
 component. Each card shows the child's avatar emoji, name and calculated age.
+The age is computed by the `getAgeFromBirthday` helper in `src/utils/age.js`.
 Tapping a card selects that profile and navigates to the learning hub. Cards
 include ✏️ and 🗑️ buttons for editing or deleting a profile. A final "➕ Add
 Another Child" card links back to the onboarding form.

--- a/src/components/KidSelector.jsx
+++ b/src/components/KidSelector.jsx
@@ -1,17 +1,10 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useProfiles } from '../contexts/ProfileProvider';
+import { getAgeFromBirthday } from '../utils/age';
 
-function calcAge(birthday) {
-  if (!birthday) return '-';
-  const birth = new Date(birthday);
-  if (Number.isNaN(birth.getTime())) return '-';
-  const today = new Date();
-  let age = today.getFullYear() - birth.getFullYear();
-  const m = today.getMonth() - birth.getMonth();
-  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) {
-    age -= 1;
-  }
-  return age;
+function displayAge(birthday) {
+  const age = getAgeFromBirthday(birthday);
+  return Number.isNaN(age) ? '-' : age;
 }
 
 export default function KidSelector() {
@@ -63,7 +56,7 @@ export default function KidSelector() {
             </div>
             <div className="font-semibold">{p.name}</div>
             <div className="text-sm text-gray-600">
-              {calcAge(p.birthday)} years
+              {displayAge(p.birthday)} years
             </div>
             <div className="flex justify-center space-x-2 pt-2">
               <button

--- a/src/screens/SelectKid.jsx
+++ b/src/screens/SelectKid.jsx
@@ -1,12 +1,13 @@
-import { useProfiles } from '../contexts/ProfileProvider';
+import KidSelector from '../components/KidSelector';
 
 export default function SelectKid() {
-  const { profiles } = useProfiles();
   return (
-    <div className="p-4" data-testid="select-kid">
-      {profiles.map((p) => (
-        <div key={p.id}>{p.name}</div>
-      ))}
+    <div
+      className="p-4 flex flex-col items-center justify-center min-h-screen bg-white text-black"
+      data-testid="select-kid"
+    >
+      <h1 className="text-2xl font-bold mb-6">Who’s learning today?</h1>
+      <KidSelector />
     </div>
   );
 }

--- a/src/screens/SelectKid.test.jsx
+++ b/src/screens/SelectKid.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SelectKid from './SelectKid';
+
+jest.mock('../components/KidSelector', () => () => (
+  <div data-testid="kid-selector">selector</div>
+));
+
+test('renders heading and kid selector', () => {
+  render(
+    <MemoryRouter>
+      <SelectKid />
+    </MemoryRouter>
+  );
+  expect(screen.getByText("Who’s learning today?")).toBeInTheDocument();
+  expect(screen.getByTestId('kid-selector')).toBeInTheDocument();
+});

--- a/src/utils/age.js
+++ b/src/utils/age.js
@@ -1,0 +1,13 @@
+export function getAgeFromBirthday(birthday) {
+  const birth = new Date(birthday);
+  if (Number.isNaN(birth.getTime())) {
+    return NaN;
+  }
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age;
+}

--- a/tests/age.test.js
+++ b/tests/age.test.js
@@ -1,0 +1,12 @@
+import { getAgeFromBirthday } from '../src/utils/age.js';
+
+test('calculates age in years', () => {
+  const birth = new Date();
+  birth.setFullYear(birth.getFullYear() - 5);
+  const dateStr = birth.toISOString();
+  expect(getAgeFromBirthday(dateStr)).toBe(5);
+});
+
+test('returns NaN for invalid date', () => {
+  expect(Number.isNaN(getAgeFromBirthday('invalid'))).toBe(true);
+});


### PR DESCRIPTION
## Summary
- style the SelectKid screen and show KidSelector grid
- compute ages via new `getAgeFromBirthday` helper
- use helper inside KidSelector
- document helper in README
- test SelectKid screen and age utility

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b9f8d883c832e84da35dde9a6296a