### PR TITLE
Improve kid profile UX with modals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ const RoutesWithProfiles = () => {
         path="/"
         element={profiles.length === 0 ? <OnboardingHome /> : <Navigate to="/select-kid" />}
       />
+      <Route path="/onboarding" element={<OnboardingHome />} />
       <Route path="/select-kid" element={<SelectKid />} />
       <Route path="/learning-hub" element={<LearningHub />} />
       <Route path="/progress" element={<Progress />} />

--- a/src/components/DeleteConfirmModal.jsx
+++ b/src/components/DeleteConfirmModal.jsx
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+
+export default function DeleteConfirmModal({ open, onClose, name, onConfirm }) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <div className="space-y-4 text-center">
+        <p>Are you sure you want to delete {name}?</p>
+        <div className="flex justify-end space-x-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => { onConfirm(); onClose(); }}
+            className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-500"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+DeleteConfirmModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};

--- a/src/components/EditProfileModal.jsx
+++ b/src/components/EditProfileModal.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+
+export default function EditProfileModal({ open, onClose, profile, onSave }) {
+  const [name, setName] = useState(profile.name);
+  const [birthday, setBirthday] = useState(profile.birthday || '');
+  const [avatar, setAvatar] = useState(profile.avatar || '');
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSave({ name: name.trim(), birthday, avatar });
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <h2 className="text-lg font-bold text-center">Edit Profile</h2>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border rounded p-2 w-full"
+          aria-label="name"
+          required
+        />
+        <input
+          type="date"
+          value={birthday}
+          onChange={(e) => setBirthday(e.target.value)}
+          className="border rounded p-2 w-full"
+          aria-label="date of birth"
+          required
+        />
+        <input
+          type="text"
+          value={avatar}
+          onChange={(e) => setAvatar(e.target.value)}
+          className="border rounded p-2 w-full"
+          aria-label="avatar"
+        />
+        <div className="flex justify-end space-x-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-500"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+EditProfileModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  profile: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    birthday: PropTypes.string,
+    avatar: PropTypes.string,
+  }).isRequired,
+  onSave: PropTypes.func.isRequired,
+};

--- a/src/components/KidSelector.jsx
+++ b/src/components/KidSelector.jsx
@@ -1,6 +1,9 @@
 import { Link, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { useProfiles } from '../contexts/ProfileProvider';
 import { getAgeFromBirthday } from '../utils/age';
+import EditProfileModal from './EditProfileModal';
+import DeleteConfirmModal from './DeleteConfirmModal';
 
 function displayAge(birthday) {
   const age = getAgeFromBirthday(birthday);
@@ -15,25 +18,22 @@ export default function KidSelector() {
     editProfile,
   } = useProfiles();
   const navigate = useNavigate();
+  const [editing, setEditing] = useState(null);
+  const [deleting, setDeleting] = useState(null);
 
   const handleSelect = (id) => {
     selectProfile(id);
     navigate('/learning-hub');
   };
 
-  const handleDelete = (e, id) => {
+  const handleDelete = (e, p) => {
     e.stopPropagation();
-    if (window.confirm('Delete this profile?')) {
-      deleteProfile(id);
-    }
+    setDeleting(p);
   };
 
-  const handleEdit = (e, id, name) => {
+  const handleEdit = (e, p) => {
     e.stopPropagation();
-    const newName = window.prompt('New name', name);
-    if (newName) {
-      editProfile(id, { name: newName });
-    }
+    setEditing(p);
   };
 
   return (
@@ -49,9 +49,9 @@ export default function KidSelector() {
               if (e.key === 'Enter') handleSelect(p.id);
             }}
             aria-label={`Select ${p.name}`}
-            className="card space-y-1 text-center cursor-pointer"
+            className="card space-y-1 text-center cursor-pointer hover:ring-2 focus:ring-2 ring-blue-500 transition focus:outline-none"
           >
-            <div className="text-6xl" aria-label="avatar">
+            <div className="text-7xl" aria-label="avatar">
               {p.avatar}
             </div>
             <div className="font-semibold">{p.name}</div>
@@ -61,7 +61,7 @@ export default function KidSelector() {
             <div className="flex justify-center space-x-2 pt-2">
               <button
                 type="button"
-                onClick={(e) => handleEdit(e, p.id, p.name)}
+                onClick={(e) => handleEdit(e, p)}
                 aria-label={`Edit ${p.name}`}
                 className="icon-btn hover:bg-gray-200"
               >
@@ -69,7 +69,7 @@ export default function KidSelector() {
               </button>
               <button
                 type="button"
-                onClick={(e) => handleDelete(e, p.id)}
+                onClick={(e) => handleDelete(e, p)}
                 aria-label={`Delete ${p.name}`}
                 className="icon-btn hover:bg-gray-200"
               >
@@ -80,11 +80,27 @@ export default function KidSelector() {
         ))}
         <Link
           to="/onboarding"
-          className="card flex items-center justify-center text-xl font-semibold"
+          className="card flex items-center justify-center text-xl font-semibold hover:ring-2 focus:ring-2 ring-blue-500 transition focus:outline-none"
         >
           ➕ Add Another Child
         </Link>
       </div>
+      {editing && (
+        <EditProfileModal
+          open={Boolean(editing)}
+          onClose={() => setEditing(null)}
+          profile={editing}
+          onSave={(data) => editProfile(editing.id, data)}
+        />
+      )}
+      {deleting && (
+        <DeleteConfirmModal
+          open={Boolean(deleting)}
+          onClose={() => setDeleting(null)}
+          name={deleting.name}
+          onConfirm={() => deleteProfile(deleting.id)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/KidSelector.test.jsx
+++ b/src/components/KidSelector.test.jsx
@@ -44,26 +44,25 @@ test('selects profile and navigates to hub', () => {
 
 test('deletes profile when confirmed', () => {
   const { deleteProfile } = useProfiles.mock.results[0].value;
-  window.confirm = jest.fn(() => true);
   render(
     <MemoryRouter>
       <KidSelector />
     </MemoryRouter>,
   );
   fireEvent.click(screen.getByLabelText('Delete Sam'));
-  expect(window.confirm).toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
   expect(deleteProfile).toHaveBeenCalledWith('1');
 });
 
 test('edits profile name', () => {
   const { editProfile } = useProfiles.mock.results[0].value;
-  window.prompt = jest.fn(() => 'Sally');
   render(
     <MemoryRouter>
       <KidSelector />
     </MemoryRouter>,
   );
   fireEvent.click(screen.getByLabelText('Edit Sam'));
-  expect(window.prompt).toHaveBeenCalled();
-  expect(editProfile).toHaveBeenCalledWith('1', { name: 'Sally' });
+  fireEvent.change(screen.getByLabelText('name'), { target: { value: 'Sally' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(editProfile).toHaveBeenCalledWith('1', expect.objectContaining({ name: 'Sally' }));
 });

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+
+export default function Modal({ open, onClose, children }) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-white p-4 rounded-lg shadow-lg w-80">
+        {children}
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-4 px-3 py-1 bg-gray-200 rounded hover:bg-gray-300"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+Modal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/screens/OnboardingHome.jsx
+++ b/src/screens/OnboardingHome.jsx
@@ -22,7 +22,12 @@ export default function OnboardingHome() {
       setError('Name is required');
       return;
     }
-    if (birthday && Number.isNaN(new Date(birthday).getTime())) {
+    if (!birthday) {
+      setError('Birthday is required');
+      return;
+    }
+    const dateVal = new Date(birthday);
+    if (Number.isNaN(dateVal.getTime()) || dateVal > new Date()) {
       setError('Invalid date');
       return;
     }
@@ -36,7 +41,7 @@ export default function OnboardingHome() {
         onSubmit={handleSubmit}
         className="space-y-4 bg-white p-6 shadow rounded w-full max-w-xs"
       >
-        <h1 className="text-xl font-bold text-center">Welcome!</h1>
+        <h1 className="text-xl font-bold text-center">Let’s add your first explorer!</h1>
         {error && (
           <div className="text-red-600" role="alert">
             {error}
@@ -52,6 +57,7 @@ export default function OnboardingHome() {
           value={name}
           onChange={(e) => setName(e.target.value)}
           className="border rounded p-2 w-full"
+          required
         />
         <label htmlFor="dob" className="sr-only">
           Date of Birth
@@ -63,6 +69,7 @@ export default function OnboardingHome() {
           onChange={(e) => setBirthday(e.target.value)}
           className="border rounded p-2 w-full"
           aria-label="date of birth"
+          required
         />
         <div className="flex items-center justify-between">
           <span className="text-3xl" aria-label="avatar">
@@ -80,7 +87,7 @@ export default function OnboardingHome() {
           type="submit"
           className="bg-indigo-600 text-white w-full py-2 rounded"
         >
-          Create Profile
+          Save and Start
         </button>
       </form>
     </div>

--- a/src/screens/OnboardingHome.test.jsx
+++ b/src/screens/OnboardingHome.test.jsx
@@ -29,7 +29,7 @@ test('submits valid form and redirects', () => {
   fireEvent.change(screen.getByLabelText(/date of birth/i), {
     target: { value: '2020-01-01' },
   });
-  fireEvent.click(screen.getByRole('button', { name: /create profile/i }));
+  fireEvent.click(screen.getByRole('button', { name: /save and start/i }));
 
   expect(mockNavigate).toHaveBeenCalledWith('/select-kid');
   const stored = JSON.parse(localStorage.getItem(PROFILES_KEY));
@@ -45,7 +45,28 @@ test('shows error for missing name', () => {
     </MemoryRouter>
   );
 
-  fireEvent.click(screen.getByRole('button', { name: /create profile/i }));
+  fireEvent.click(screen.getByRole('button', { name: /save and start/i }));
   expect(screen.getByRole('alert')).toHaveTextContent(/name is required/i);
+});
+
+test('blocks future birth dates', () => {
+  render(
+    <MemoryRouter>
+      <ProfileProvider>
+        <OnboardingHome />
+      </ProfileProvider>
+    </MemoryRouter>,
+  );
+
+  fireEvent.change(screen.getByLabelText(/name/i), {
+    target: { value: 'Tim' },
+  });
+  const future = new Date();
+  future.setFullYear(future.getFullYear() + 1);
+  fireEvent.change(screen.getByLabelText(/date of birth/i), {
+    target: { value: future.toISOString().slice(0, 10) },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /save and start/i }));
+  expect(screen.getByRole('alert')).toHaveTextContent(/invalid date/i);
 });
 

--- a/src/screens/SelectKid.jsx
+++ b/src/screens/SelectKid.jsx
@@ -3,7 +3,7 @@ import KidSelector from '../components/KidSelector';
 export default function SelectKid() {
   return (
     <div
-      className="p-4 flex flex-col items-center justify-center min-h-screen bg-white text-black"
+      className="p-4 flex flex-col items-center justify-center min-h-screen bg-[url('/images/kid-selector.svg')] bg-cover text-black"
       data-testid="select-kid"
     >
       <h1 className="text-2xl font-bold mb-6">Who’s learning today?</h1>


### PR DESCRIPTION
## Summary
- add onboarding route and update onboarding screen copy and validation
- add modal components for editing and deleting profiles
- enhance KidSelector cards and background
- update tests for new modals and validation logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ba2b6738c832e9a410e48876f7ec6