### PR TITLE
Display progress summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ the dashboard and see completed weeks and earned badges.
 
 ![Learning Hub](public/images/learning-hub.svg)
 
+## Viewing Progress
+
+The Progress screen summarizes overall completion for the selected child.
+At the top a large header shows the current term, week, day and session using
+the same progress strip as the dashboard. Any badges the child has earned are
+displayed below this header.
+
+A grid lists all 41 weeks. Completed weeks appear green while the current week
+is highlighted in purple. Future weeks remain gray so parents can quickly scan
+which parts of the curriculum are finished.
+
 ## Home Screen
 
 The top of the page includes a sticky `NavBar` with a centered **FlinkDink**

--- a/src/screens/Progress.jsx
+++ b/src/screens/Progress.jsx
@@ -1,7 +1,51 @@
+import DashboardHeader from '../components/DashboardHeader';
+import { useContent, TOTAL_WEEKS } from '../contexts/ContentProvider';
+import { useProfiles } from '../contexts/ProfileProvider';
+import { BADGE_MAP } from '../utils/badges';
+
 export default function Progress() {
+  const { progress } = useContent();
+  const { selectedProfile } = useProfiles();
+
+  if (!selectedProfile) {
+    return null;
+  }
+
+  const weeks = Array.from({ length: TOTAL_WEEKS }, (_, i) => i + 1);
+
   return (
-    <div className="p-4" data-testid="progress-screen">
-      Progress Page
+    <div className="p-4 space-y-4" data-testid="progress-screen">
+      <DashboardHeader />
+      {selectedProfile.badges.length > 0 && (
+        <div className="flex justify-center space-x-2" data-testid="badge-list">
+          {selectedProfile.badges.map((b) => (
+            <span key={b} role="img" aria-label={BADGE_MAP[b].label}>
+              {BADGE_MAP[b].icon}
+            </span>
+          ))}
+        </div>
+      )}
+      <h2 className="text-xl font-semibold">Overall Progress</h2>
+      <div
+        className="grid grid-cols-7 sm:grid-cols-13 gap-1 text-center"
+        data-testid="weeks-grid"
+      >
+        {weeks.map((w) => (
+          <div
+            key={w}
+            data-testid={`week-cell-${w}`}
+            className={`border p-1 rounded ${
+              w < progress.week
+                ? 'bg-green-300'
+                : w === progress.week
+                  ? 'bg-indigo-200'
+                  : 'bg-gray-200'
+            }`}
+          >
+            {w}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/screens/Progress.test.jsx
+++ b/src/screens/Progress.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import Progress from './Progress';
+import { useContent } from '../contexts/ContentProvider';
+import { useProfiles } from '../contexts/ProfileProvider';
+
+const { TOTAL_WEEKS } = jest.requireActual('../contexts/ContentProvider');
+
+jest.mock('../contexts/ContentProvider');
+jest.mock('../contexts/ProfileProvider');
+
+describe('Progress screen', () => {
+  it('renders progress info and badges', () => {
+    useContent.mockReturnValue({
+      progress: { week: 2, day: 3, session: 1 },
+    });
+    useProfiles.mockReturnValue({
+      selectedProfile: { badges: ['first-day'] },
+    });
+
+    render(<Progress />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Term 1 \u00B7 Week 2 \u00B7 Day 3 \u00B7 Session 1',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('badge-list')).toHaveTextContent('🎈');
+
+    const cells = screen.getAllByTestId(/week-cell-/);
+    expect(cells).toHaveLength(TOTAL_WEEKS);
+    expect(screen.getByTestId('week-cell-1')).toHaveClass('bg-green-300');
+    expect(screen.getByTestId('week-cell-2')).toHaveClass('bg-indigo-200');
+  });
+});


### PR DESCRIPTION
## Summary
- update Progress screen with real progress data
- render earned badges and overall week grid
- add tests for Progress screen
- document how to view progress

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bae2d00e8832ebbd6a3b46dc8c40b