### PR TITLE
Add logout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,9 @@ register a new account using the **Sign Up** page. Successful authentication
 returns a token stored in `localStorage` by the `AuthProvider`.
 Access this context via the `useAuth` hook exported from
 `src/contexts/authHelpers.js`.
+To sign out, tap the **Log Out** button in the navigation bar or call
+`useAuth().logout()` directly. This clears the saved token and redirects
+back to the `/login` page.
 
 During development the API server runs on `http://localhost:3001`, so the
 `VITE_API_BASE_URL` variable should point there. For production builds set it to

--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/authHelpers';
+
+const LogoutButton = () => {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex flex-col items-center text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500 text-gray-600"
+    >
+      <span aria-hidden="true">🚪</span>
+      <span>Log Out</span>
+    </button>
+  );
+};
+
+export default LogoutButton;

--- a/src/components/LogoutButton.test.jsx
+++ b/src/components/LogoutButton.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LogoutButton from './LogoutButton';
+import { useAuth } from '../contexts/authHelpers';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../contexts/authHelpers');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('logs out and redirects to login', () => {
+  const logout = jest.fn();
+  useAuth.mockReturnValue({ logout });
+
+  render(
+    <MemoryRouter>
+      <LogoutButton />
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /log out/i }));
+  expect(logout).toHaveBeenCalled();
+  expect(mockNavigate).toHaveBeenCalledWith('/login');
+});

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,4 +1,5 @@
 import { NavLink, useLocation } from 'react-router-dom';
+import LogoutButton from './LogoutButton';
 
 const NAV_ITEMS = [
   { to: '/learning-hub', label: 'Home', icon: '🏠' },
@@ -29,6 +30,7 @@ const NavBar = () => {
           </NavLink>
         );
       })}
+      <LogoutButton />
     </nav>
   );
 };

--- a/src/components/NavBar.test.jsx
+++ b/src/components/NavBar.test.jsx
@@ -17,6 +17,7 @@ describe('NavBar', () => {
     expect(screen.getByRole('link', { name: /curriculum/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /progress/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
   })
 
   it('highlights the active tab', () => {


### PR DESCRIPTION
## Summary
- add reusable `LogoutButton` component
- insert logout button in the NavBar
- document logout usage in README
- validate logout with new unit tests

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685baf84bbe8832ea6db3b2e587e584f