### PR TITLE
Improve auth error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,6 +908,9 @@ UNSPLASH_SECRET_KEY=your-unsplash-secret
 The default credentials are **demo@example.com** / **password**. You can also
 register a new account using the **Sign Up** page. Successful authentication
 returns a token stored in `localStorage` by the `AuthProvider`.
+Server responses include a `detail` field when something goes wrong; these
+messages are now surfaced on the login and sign‑up pages so users know exactly
+what happened.
 Access this context via the `useAuth` hook exported from
 `src/contexts/authHelpers.js`.
 To sign out, tap the **Log Out** button in the navigation bar or call

--- a/src/screens/Login.jsx
+++ b/src/screens/Login.jsx
@@ -17,7 +17,7 @@ export default function Login() {
       navigate('/');
     } catch (err) {
       console.error('Login failed', err);
-      setError('Invalid email or password');
+      setError(err.detail || 'Invalid email or password');
     }
   };
 

--- a/src/screens/Login.test.jsx
+++ b/src/screens/Login.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '../contexts/AuthProvider';
 import Login from './Login';
@@ -14,4 +14,34 @@ test('renders login form', () => {
   expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
   expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+});
+
+test('shows server error detail on failed login', async () => {
+  process.env.VITE_API_BASE_URL = '';
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 422,
+    text: async () => JSON.stringify({ detail: 'Invalid credentials' }),
+  });
+
+  render(
+    <BrowserRouter>
+      <AuthProvider>
+        <Login />
+      </AuthProvider>
+    </BrowserRouter>,
+  );
+
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@test.com' } });
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'bad' } });
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+  await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete global.fetch;
+  delete process.env.VITE_API_BASE_URL;
 });

--- a/src/screens/SignUp.jsx
+++ b/src/screens/SignUp.jsx
@@ -17,7 +17,7 @@ export default function SignUp() {
       navigate('/');
     } catch (err) {
       console.error('Registration failed', err);
-      setError('Could not register');
+      setError(err.detail || 'Could not register');
     }
   };
 

--- a/src/screens/SignUp.test.jsx
+++ b/src/screens/SignUp.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '../contexts/AuthProvider';
 import SignUp from './SignUp';
@@ -14,4 +14,34 @@ test('renders sign up form', () => {
   expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
   expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+});
+
+test('shows server error detail on failed registration', async () => {
+  process.env.VITE_API_BASE_URL = '';
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 422,
+    text: async () => JSON.stringify({ detail: 'User already exists' }),
+  });
+
+  render(
+    <BrowserRouter>
+      <AuthProvider>
+        <SignUp />
+      </AuthProvider>
+    </BrowserRouter>,
+  );
+
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'dup@test.com' } });
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: '123' } });
+  fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+  await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  expect(screen.getByRole('alert')).toHaveTextContent('User already exists');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete global.fetch;
+  delete process.env.VITE_API_BASE_URL;
 });


### PR DESCRIPTION
## Summary
- parse server errors in `AuthProvider` and expose `detail`
- warn when login or registration returns HTTP 422
- surface server messages in Login and SignUp screens
- document surfacing of `detail` responses
- add tests for displaying login/register errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bb1ba4e3c832ebc221725470a886b