### PR TITLE
Add profile edit validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Tapping a card selects that profile and navigates to the learning hub. Cards
 include ✏️ and 🗑️ buttons for editing or deleting a profile. A final "➕ Add
 Another Child" card links back to the onboarding form.
 
+Editing uses the same validations as the onboarding form. If the name field is
+blank or the birthday is missing or set in the future, an inline error message
+appears and the save action is blocked.
+
 ![Kid selector grid](public/images/kid-selector.svg)
 
 Select a different card at any time to switch children. The newly chosen

--- a/src/components/EditProfileModal.jsx
+++ b/src/components/EditProfileModal.jsx
@@ -6,10 +6,23 @@ export default function EditProfileModal({ isOpen, onClose, profile, onSave }) {
   const [name, setName] = useState(profile.name);
   const [birthday, setBirthday] = useState(profile.birthday);
   const [avatar, setAvatar] = useState(profile.avatar || '🐼');
+  const [error, setError] = useState('');
 
   const handleSubmit = () => {
-    if (!name.trim()) return;
-    onSave({ ...profile, name, birthday, avatar });
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
+    if (!birthday) {
+      setError('Birthday is required');
+      return;
+    }
+    const dateVal = new Date(birthday);
+    if (Number.isNaN(dateVal.getTime()) || dateVal > new Date()) {
+      setError('Invalid date');
+      return;
+    }
+    onSave({ ...profile, name: name.trim(), birthday, avatar });
     onClose();
   };
 
@@ -18,6 +31,12 @@ export default function EditProfileModal({ isOpen, onClose, profile, onSave }) {
       <Dialog.Overlay className="fixed inset-0 bg-black/30 backdrop-blur-sm" />
       <div className="bg-white rounded-2xl p-6 w-[90%] max-w-md shadow-lg relative z-10">
         <Dialog.Title className="text-xl font-bold mb-4">Edit Profile</Dialog.Title>
+
+        {error && (
+          <div className="text-red-600 mb-2" role="alert">
+            {error}
+          </div>
+        )}
 
         <div className="space-y-4">
           <label className="block">

--- a/src/components/KidSelector.test.jsx
+++ b/src/components/KidSelector.test.jsx
@@ -66,3 +66,33 @@ test('edits profile name', () => {
   fireEvent.click(screen.getByRole('button', { name: 'Save' }));
   expect(editProfile).toHaveBeenCalledWith('1', expect.objectContaining({ name: 'Sally' }));
 });
+
+test('shows error for blank name when editing', () => {
+  const { editProfile } = useProfiles.mock.results[0].value;
+  render(
+    <MemoryRouter>
+      <KidSelector />
+    </MemoryRouter>,
+  );
+  fireEvent.click(screen.getByLabelText('Edit Sam'));
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: '' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(screen.getByRole('alert')).toHaveTextContent(/name is required/i);
+  expect(editProfile).not.toHaveBeenCalled();
+});
+
+test('blocks future birthday when editing', () => {
+  const { editProfile } = useProfiles.mock.results[0].value;
+  render(
+    <MemoryRouter>
+      <KidSelector />
+    </MemoryRouter>,
+  );
+  fireEvent.click(screen.getByLabelText('Edit Sam'));
+  const future = new Date();
+  future.setFullYear(future.getFullYear() + 1);
+  fireEvent.change(screen.getByLabelText('Birthday'), { target: { value: future.toISOString().slice(0, 10) } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  expect(screen.getByRole('alert')).toHaveTextContent(/invalid date/i);
+  expect(editProfile).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- validate name and birthday in EditProfileModal like onboarding
- show inline errors when editing profiles
- test error handling in KidSelector
- document editing validations in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb40dc3fc832e8d4f830ad86540dd